### PR TITLE
BACKLOG-11435 - Use hit field for created property

### DIFF
--- a/src/javascript/app/App.jsx
+++ b/src/javascript/app/App.jsx
@@ -13,7 +13,7 @@ let fields = [
     new Field(FieldType.HIT, 'lastModified'),
     new Field(FieldType.HIT, 'lastModifiedBy'),
     new Field(FieldType.HIT, 'createdBy'),
-    new Field(FieldType.NODE, 'jcr:created', 'created')
+    new Field(FieldType.HIT, 'created')
 ];
 
 function configureConnector(dxContext) {


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-11435

## Description

Use created field from hit object
