### PR TITLE
test: containerised Jahia + Augmented Search environment with Playwright tests

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -25,7 +25,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Jahia/jahia-modules-action/static-analysis@v2
         with:
-          node_version: 18
+          # 18 can no longer install this repo's devDependencies: @babel/cli@8.0.0-beta.2 requires
+          # node ^20.19.0 || >=22.12.0, so `yarn` fails before linting even starts. This was already
+          # broken on main — recent merges were all [skip ci] chore syncs, so nothing surfaced it.
+          node_version: 22
           auditci_level: critical
 
   build:
@@ -57,24 +60,56 @@ jobs:
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
 
+  # Deliberately NOT jahia-modules-action/integration-tests: that action drives the environment
+  # through `docker-compose` (Compose v1), which is no longer present on ubuntu-latest, and it
+  # discards the underlying error ("There was an issue processing the command") so failures are
+  # undiagnosable. Everything it did for us is a handful of plain `docker compose` calls, and
+  # tests/docker-compose.yml + tests/provision.sh are exactly what we run locally.
   integration-tests:
     name: Integration Tests
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      COMPOSE: docker compose -f tests/docker-compose.yml
+      JAHIA_LICENSE: ${{ secrets.JAHIA_LICENSE }}
     steps:
       - uses: actions/checkout@v4
-      - uses: jahia/jahia-modules-action/integration-tests@v2
+
+      # The build job publishes the jar as `build-artifacts` with a `target/` prefix, which is
+      # where tests/docker-compose.yml expects it (mounted read-only at /artifacts).
+      - name: Download the module jar from the build job
+        uses: actions/download-artifact@v4
         with:
-          module_id: augmented-search-ui
-          # Pinned stable Jahia: this environment doubles as the one customers run, so it must not
-          # depend on a snapshot. See tests/README.md.
-          jahia_image: jahia/jahia-ee:8.2
-          # Elasticsearch is BUILT by tests/docker-compose.yml (stock ES + the analysis plugins
-          # augmented-search needs), so no elasticsearch_image is passed here.
-          tests_manifest: provisioning-manifest-stable.yml
-          tests_container_name: playwright
-          tests_report_path: results
-          tests_report_type: xml
-          jahia_license: ${{ secrets.JAHIA_LICENSE }}
-          nexus_username: ${{ secrets.NEXUS_USERNAME }}
-          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          name: build-artifacts
+          path: .
+
+      - name: Show what will be deployed
+        run: ls -l target/*.jar
+
+      - name: Start Jahia, Elasticsearch and the database
+        run: |
+          mkdir -p tests/results
+          $COMPOSE up -d --build elasticsearch jahia
+
+      # provision.sh (inside the tests container) waits for Jahia, applies the manifest, deploys the
+      # module, places the component and waits for real indices before Playwright starts.
+      - name: Provision the environment and run the tests
+        run: $COMPOSE up --build --abort-on-container-exit --exit-code-from playwright playwright
+
+      - name: Collect container logs
+        if: always()
+        run: $COMPOSE logs --no-color --timestamps --tail=all > tests/results/containers.log 2>&1 || true
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-results
+          path: tests/results
+          retention-days: 7
+          if-no-files-found: warn
+
+      - name: Tear down
+        if: always()
+        run: $COMPOSE down -v --remove-orphans || true

--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -56,3 +56,25 @@ jobs:
           github_pr_id: ${{github.event.number}}
           sonar_url: ${{ secrets.SONAR_URL }}
           sonar_token: ${{ secrets.SONAR_TOKEN }}
+
+  integration-tests:
+    name: Integration Tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/integration-tests@v2
+        with:
+          module_id: augmented-search-ui
+          # Pinned stable Jahia: this environment doubles as the one customers run, so it must not
+          # depend on a snapshot. See tests/README.md.
+          jahia_image: jahia/jahia-ee:8.2
+          # Elasticsearch is BUILT by tests/docker-compose.yml (stock ES + the analysis plugins
+          # augmented-search needs), so no elasticsearch_image is passed here.
+          tests_manifest: provisioning-manifest-stable.yml
+          tests_container_name: playwright
+          tests_report_path: results
+          tests_report_type: xml
+          jahia_license: ${{ secrets.JAHIA_LICENSE }}
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ src/main/resources/javascript/app
 yarn-error.log
 /.env
 /yalc.lock
+
+# tests environment
+tests/node_modules/
+tests/results/
+tests/package-lock.json

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,24 @@
+# Test runner image: Playwright + the provisioning tooling.
+#
+# The base image tag MUST match the @playwright/test version in package.json — Playwright refuses to
+# run against browsers it wasn't built for.
+FROM mcr.microsoft.com/playwright:v1.62.0-jammy
+
+# jq builds the GraphQL request bodies in provision.sh; curl talks to Jahia.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl jq \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash jahians
+USER jahians
+WORKDIR /home/jahians
+
+COPY --chown=jahians:jahians package.json package-lock.json* ./
+# CI=true keeps the install logs terse. Browsers already live in the base image.
+RUN CI=true npm install --no-audit --no-fund
+
+COPY --chown=jahians:jahians . .
+
+# Provision first, then run the suite; provision.sh execs its arguments once the environment is up.
+ENTRYPOINT ["./provision.sh"]
+CMD ["npx", "playwright", "test"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,114 @@
+# Test / demo environment
+
+A complete Jahia + Augmented Search environment for this module: Jahia, Elasticsearch, the Digitall
+demo site indexed for search, and `augmented-search-ui` deployed on top.
+
+Two audiences, one environment:
+
+- **CI** — integration tests run against it on every change.
+- **You, or a customer** — the fastest way to see this module actually working before forking it.
+
+Everything is pinned to **stable, released versions**, on purpose. If you add a coordinate here,
+never point it at a `-SNAPSHOT`.
+
+## What you need
+
+- Docker with Compose v2
+- **A Jahia licence.** We can't ship one. Export it base64-encoded:
+  ```bash
+  export JAHIA_LICENSE=$(base64 -i /path/to/your/license.xml)
+  ```
+  (Augmented Search is licence-gated — see Troubleshooting.)
+
+## Run it
+
+```bash
+cd tests
+export JAHIA_LICENSE=$(base64 -i /path/to/your/license.xml)
+
+# Start the platform. Jahia takes a few minutes on a cold start.
+docker compose up -d elasticsearch jahia
+
+# Provision the environment and run the tests.
+docker compose up --build --abort-on-container-exit playwright
+```
+
+Then open <http://localhost:8080/sites/digitall/home.html> (`root` / `root1234`) — the search
+component sits on the Digitall home page. Elasticsearch is on <http://localhost:9200>.
+
+The test container provisions before testing, so the first run takes a while: Digitall is installed
+and imported, Augmented Search is configured, and the site is indexed.
+
+To test the module you just built, build it first — the jar in `../target` is picked up
+automatically:
+
+```bash
+(cd .. && mvn clean package -DskipTests)
+```
+
+Without a local jar, the released version is installed instead, so the environment still works
+standalone.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | The environment: `mariadb`, `elasticsearch`, `jahia`, `playwright`. |
+| `elasticsearch/Dockerfile` | Elasticsearch **plus the analysis plugins Augmented Search needs**. |
+| `provisioning-manifest-stable.yml` | The platform: Digitall, Augmented Search, the JS-modules engine, ES configuration. |
+| `index-digitall.graphql` | Registers Digitall with Augmented Search and starts indexation. |
+| `provision.sh` | Waits for Jahia, applies the manifest, deploys/enables the module, places the component, waits for indices — then runs the tests. |
+| `e2e/` | Playwright specs. |
+| `results/` | Reports, traces, screenshots (git-ignored). |
+
+## Running the tests from your host
+
+Useful while writing specs — you get `--headed` and `--ui`:
+
+```bash
+cd tests && npm install
+JAHIA_URL=http://localhost:8080 npm run test:ui
+```
+
+This assumes the environment is already provisioned (i.e. you have run the `playwright` service at
+least once).
+
+## Troubleshooting
+
+**Every search fails, and Elasticsearch has no `jahia_as*` indices.**
+Indexation is asynchronous, and its mutation reports success *even when the job then fails* — so
+never trust the provisioning output. Check the end state:
+```bash
+curl 'http://localhost:9200/_cat/indices?v'
+docker compose logs jahia | grep -iE 'ReindexJob|ERROR'
+```
+
+**`failed to find tokenizer under name [icu_tokenizer]`.**
+Elasticsearch is missing Augmented Search's analysis plugins. That's why `elasticsearch` is built
+from `elasticsearch/Dockerfile` rather than pulled — if you point `ELASTICSEARCH_IMAGE` at stock
+Elasticsearch, you get exactly this.
+
+**`augmented-search` installs but never starts.**
+It is licence-gated (`require-capability … search-provider-elasticsearch`). A licence without the
+Augmented Search entitlement leaves the bundle installed and stopped, which looks like a deployment
+bug. Check with `docker compose logs jahia | grep augmented-search`.
+
+**GraphQL returns `Permission denied` for everything.**
+The request is missing an `Origin` header matching the Jahia URL — without it Jahia treats the call
+as unauthenticated, whatever credentials you sent. Basic auth is fine; the header is what's missing.
+
+**Jahia answers `/cms/login` but nothing is provisioned yet.**
+Readiness is not the same as provisioned. `provision.sh` waits for the real end state; if you're
+driving things by hand, do the same.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `JAHIA_LICENSE` | *(none — required)* | Base64-encoded licence content. |
+| `JAHIA_IMAGE` | `jahia/jahia-ee:8.2` | Jahia image. CI may point this at a snapshot. |
+| `ES_BASE_IMAGE` | `docker.elastic.co/elasticsearch/elasticsearch:9.1.3` | Base for the built ES image. Keep in step with the client `elasticsearch-connector` bundles. |
+| `SUPER_USER_PASSWORD` | `root1234` | Jahia `root` password. |
+| `MANIFEST` | `provisioning-manifest-stable.yml` | Provisioning manifest to apply. |
+| `MODULE_JAR` | *(auto-detected in `/artifacts`)* | Explicit path to the module jar to deploy. |
+| `JAHIA_DEBUG` | `false` | Enable JPDA on `:8000`. |

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,9 +57,59 @@ standalone.
 | `elasticsearch/Dockerfile` | Elasticsearch **plus the analysis plugins Augmented Search needs**. |
 | `provisioning-manifest-stable.yml` | The platform: Digitall, Augmented Search, the JS-modules engine, ES configuration. |
 | `index-digitall.graphql` | Registers Digitall with Augmented Search and starts indexation. |
-| `provision.sh` | Waits for Jahia, applies the manifest, deploys/enables the module, places the component, waits for indices — then runs the tests. |
-| `e2e/` | Playwright specs. |
+| `provision.sh` | Waits for Jahia, applies the manifest, deploys/enables the module, places the component, waits for indexation to settle — then runs the tests. |
+| `e2e/` | Playwright specs (see below). |
+| `support/` | `expected.ts` (the values the suite asserts) and `search-page.ts` (all DOM knowledge). |
 | `results/` | Reports, traces, screenshots (git-ignored). |
+
+## What the suite covers
+
+75 tests, written as a **characterisation suite**: they record what the module does *today*, so the
+migration to a Jahia JavaScript module can be verified rather than hoped for.
+
+| Spec | Covers |
+|---|---|
+| `smoke.spec.ts` | The environment is wired up: component mounts, a search returns results, the API answers. |
+| `search.spec.ts` | Search on initial load, free-text queries, search-as-you-type, the empty state and recovery from it, special characters. |
+| `results.spec.ts` | The custom ResultView: link, title, node-type label, path breadcrumb, icon, type colour, date/author line, highlighted HTML excerpt. |
+| `facets.spec.ts` | Tags facet (values, counts, filtering, URL, deselection, checkbox state), the conditional Author facet, the absent Keywords facet, the date-range facet, and filters combined with a query. |
+| `tree-facet.spec.ts` | The bespoke Categories tree: rendering, counts, select/deselect, URL filter shape, the underline-only selection state, leaf nodes, the "+ More" threshold. |
+| `sorting-and-paging.spec.ts` | Four sort options and their URL parameters, PagingInfo wording, page navigation, disjoint pages, results-per-page. |
+| `i18n.spec.ts` | English and French chrome, results following the page language — **and three known bugs** (below). |
+| `url-state.spec.ts` | Query state in the URL and restoration from deep links: term, page, page size, sorting, facet filters, a full round-trip and back-navigation. |
+| `api.spec.ts` | The Augmented Search GraphQL API directly: guest LIVE, relevance ordering, EDIT for guests vs editors, and the `Origin` requirement. |
+
+### Three bugs are pinned as current behaviour
+
+The suite asserts these **as they are**, so the migration cannot change them by accident. When one is
+deliberately fixed, invert the matching assertion in the same commit so the change shows up in review.
+
+1. **German chrome is English.** `i18n/resources.js` registers only `en` and `fr`; `i18n/de.json`
+   exists and is complete but is never loaded, so i18next falls back to English.
+2. **Dates are always French.** `app/index.js` does `import 'moment/locale/fr'`, which makes French
+   moment's global default; the intended `moment().locale(lang)` sets the locale on a throwaway
+   instance rather than globally (`moment.locale(...)`).
+3. **The empty-results message is never translated.** `SearchView` passes a literal
+   `fallbackView="Nothing was found"` instead of the `search.fallbackMsg` key, which exists in all
+   three bundles.
+
+### Writing more tests
+
+Put DOM knowledge in `support/search-page.ts`, not in specs — the suite may move to Cypress later.
+Four traps, all of which cost a debugging cycle here:
+
+- **Don't select `input[type="text"]`.** Elastic's SearchBox renders its field with no `type`
+  attribute, so an attribute selector cannot match it. Use the textbox role.
+- **Don't select on the tree facet's classes.** They are styled-components hashes that change per
+  build.
+- **Don't put a comma-separated CSS list inside a chained locator.** Playwright splits it at the top
+  level and the second alternative escapes the container scope.
+- **Percent-encode `filters[0][field]=jcr:tags` style deep links.** Raw brackets and colons stop Jahia
+  serving the page, and the component then never mounts — which looks like a broken test.
+
+Assertions about content live in `support/expected.ts` and are deliberately exact. A fuzzy assertion
+detects no regression. If one fails after a version bump, confirm the behaviour really changed before
+editing the number.
 
 ## Running the tests from your host
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -123,12 +123,10 @@ services:
       SUPER_USER_PASSWORD: ${SUPER_USER_PASSWORD:-root1234}
       MODULE_JAR: ${MODULE_JAR:-}
     volumes:
-      # The freshly built module jar, so the tests deploy exactly what was just built.
-      # ../target is the local Maven output; ../artifacts is where CI drops the jar from the build
-      # job. provision.sh takes whichever is present and newest, and falls back to the released
-      # version if neither is.
+      # The freshly built module jar, so the tests deploy exactly what was just built. ../target is
+      # the Maven output locally, and CI downloads the build job's artifact to the same place.
+      # provision.sh falls back to the released version when it's absent.
       - ../target:/artifacts:ro
-      - ../artifacts:/artifacts-ci:ro
       - ./results:/home/jahians/results
 
 networks:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,136 @@
+# Integration-test / try-it-yourself environment for augmented-search-ui.
+#
+# Deliberately built on STABLE, released versions only: this doubles as the environment a customer
+# can use to run the module before forking it. Pin everything; never point at a -SNAPSHOT here.
+#
+# Layout follows Jahia/jahia-modules-action `integration-tests` (tests/ + docker-compose.yml + a
+# provisioning manifest + a tests container), so CI can drive it unchanged.
+#
+# Local use:
+#   cd tests
+#   export JAHIA_LICENSE=$(base64 -i /path/to/your/license.xml)
+#   docker compose up -d elasticsearch jahia     # then wait; see README.md
+#   docker compose up --abort-on-container-exit playwright
+#
+# You supply your own Jahia license — see README.md.
+
+services:
+  mariadb:
+    image: mariadb:10-focal
+    container_name: mariadb
+    mem_limit: 1gb
+    networks: [jahia-net]
+    command: >-
+      --max_allowed_packet=134217728
+      --transaction-isolation=READ-UNCOMMITTED
+      --innodb-lock-wait-timeout=10
+    environment:
+      MARIADB_ROOT_PASSWORD: mariadbP@55
+      MARIADB_DATABASE: jahia
+      MARIADB_USER: jahia
+      MARIADB_PASSWORD: jahia
+    healthcheck:
+      # root has a password, so the probe must authenticate (MYSQL_PWD); a bare
+      # `healthcheck.sh --connect` connects as root WITHOUT a password and is denied, so the
+      # service would never go healthy and depends_on would block Jahia forever.
+      test: ["CMD-SHELL", "MYSQL_PWD=\"$$MARIADB_ROOT_PASSWORD\" healthcheck.sh --connect --innodb_initialized"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # Elasticsearch is BUILT, not pulled: augmented-search creates its indices with analyzers that
+  # live in ES plugins. Against stock Elasticsearch, index creation fails and the reindex job dies
+  # with "failed to find tokenizer under name [icu_tokenizer]". See elasticsearch/Dockerfile.
+  elasticsearch:
+    build:
+      context: ./elasticsearch
+      args:
+        ES_BASE_IMAGE: ${ES_BASE_IMAGE:-docker.elastic.co/elasticsearch/elasticsearch:9.1.3}
+    image: ${ELASTICSEARCH_IMAGE:-augmented-search-ui-elasticsearch:9.1.3}
+    container_name: elasticsearch
+    mem_limit: 2gb
+    networks: [jahia-net]
+    ports:
+      - 9200:9200
+    environment:
+      discovery.type: single-node
+      # Test/demo environment only: no TLS, no auth. A real deployment must enable both and set
+      # elasticsearchConnector.user/password/useEncryption accordingly.
+      xpack.security.enabled: "false"
+      xpack.security.http.ssl.enabled: "false"
+      ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+    ulimits:
+      memlock: {soft: -1, hard: -1}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  jahia:
+    # Stable release by default. CI may override JAHIA_IMAGE to test against a snapshot.
+    image: ${JAHIA_IMAGE:-jahia/jahia-ee:8.2}
+    container_name: jahia
+    restart: 'no'
+    mem_limit: 4gb
+    networks: [jahia-net]
+    depends_on:
+      mariadb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    ports:
+      - 8080:8080
+      - 8101:8101
+      - 8000:8000
+    extra_hosts:
+      - jahia:127.0.0.1
+    environment:
+      DB_VENDOR: mariadb
+      DB_HOST: mariadb
+      DB_NAME: jahia
+      DB_USER: jahia
+      DB_PASS: jahia
+      OPERATING_MODE: development
+      PROCESSING_SERVER: 'true'
+      MAX_RAM_PERCENTAGE: 95
+      jahia_cfg_karaf_remoteShellHost: 0.0.0.0
+      # Base64-encoded license content — YOU provide this. See README.md.
+      JAHIA_LICENSE: ${JAHIA_LICENSE}
+      SUPER_USER_PASSWORD: ${SUPER_USER_PASSWORD:-root1234}
+      CLUSTER_ENABLED: ${JAHIA_CLUSTER_ENABLED:-false}
+      JPDA: ${JAHIA_DEBUG:-false}
+      # The environment is provisioned by the tests container rather than here, so a failure is
+      # visible in the test job's own log instead of buried in Jahia's startup output.
+
+  playwright:
+    build:
+      context: .
+    image: ${TESTS_IMAGE:-augmented-search-ui-tests}
+    container_name: playwright
+    # Playwright browsers need more than the default 64MB of shared memory.
+    shm_size: 1gb
+    networks: [jahia-net]
+    depends_on:
+      jahia:
+        condition: service_started
+    environment:
+      MANIFEST: ${MANIFEST:-provisioning-manifest-stable.yml}
+      JAHIA_URL: http://jahia:8080
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      SUPER_USER_PASSWORD: ${SUPER_USER_PASSWORD:-root1234}
+      MODULE_JAR: ${MODULE_JAR:-}
+    volumes:
+      # The freshly built module jar, so the tests deploy exactly what was just built.
+      # ../target is the local Maven output; ../artifacts is where CI drops the jar from the build
+      # job. provision.sh takes whichever is present and newest, and falls back to the released
+      # version if neither is.
+      - ../target:/artifacts:ro
+      - ../artifacts:/artifacts-ci:ro
+      - ./results:/home/jahians/results
+
+networks:
+  jahia-net:
+    name: jahia-net

--- a/tests/e2e/api.spec.ts
+++ b/tests/e2e/api.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { TOTAL_RESULTS } from '../support/expected.js';
+
+/**
+ * The Augmented Search GraphQL API the module sits on.
+ *
+ * Kept separate from the UI specs so that a broken index and a broken UI produce different failures.
+ * It also pins the permission model the module depends on: the connector is constructed with
+ * `apiToken: 'none'` and rides the browser's own session, so LIVE is readable by guests while EDIT is
+ * not — which is why the same component shows different results to an editor.
+ *
+ * Every request needs an `Origin` header matching the Jahia origin. Browsers add it automatically on
+ * POST; Playwright's request context does not, and without it Jahia treats the call as
+ * unauthenticated and answers "Permission denied" — an error that looks like a permissions problem
+ * rather than a missing header.
+ */
+
+const SEARCH = (workspace: 'LIVE' | 'EDIT', term = '') => `
+  query {
+    search(q: "${term}", workspace: ${workspace}) {
+      results(size: 5) {
+        totalHits
+        hits { displayableName link nodeType }
+      }
+    }
+  }`;
+
+test.describe('Augmented Search API', () => {
+  test('answers a guest LIVE search', async ({ request, baseURL }) => {
+    const response = await request.post('/modules/graphql', {
+      headers: { 'Content-Type': 'application/json', Origin: baseURL! },
+      data: { query: SEARCH('LIVE') },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.errors, `unexpected errors: ${JSON.stringify(body.errors)}`).toBeUndefined();
+    expect(body.data.search.results.totalHits).toBe(TOTAL_RESULTS);
+
+    const [hit] = body.data.search.results.hits;
+    expect(hit.displayableName).toBeTruthy();
+    expect(hit.link).toMatch(/\.html$/);
+    expect(hit.nodeType).toMatch(/^[a-z]+nt?:/i);
+  });
+
+  test('scores and orders hits for a term', async ({ request, baseURL }) => {
+    const response = await request.post('/modules/graphql', {
+      headers: { 'Content-Type': 'application/json', Origin: baseURL! },
+      data: {
+        query: `query {
+          search(q: "digitall", workspace: LIVE) {
+            results(size: 5) { totalHits hits { displayableName score } }
+          }
+        }`,
+      },
+    });
+
+    const body = await response.json();
+    expect(body.errors).toBeUndefined();
+    const hits = body.data.search.results.hits as Array<{ score: number }>;
+    expect(hits.length).toBeGreaterThan(1);
+    // Relevance ordering: scores must be non-increasing.
+    const scores = hits.map((h) => h.score);
+    expect([...scores].sort((a, b) => b - a)).toEqual(scores);
+  });
+
+  test('returns nothing to a guest for the EDIT workspace', async ({ request, baseURL }) => {
+    // Unauthenticated callers get an empty result set rather than an error — the same behaviour the
+    // module relies on when rendered on a published page.
+    const response = await request.post('/modules/graphql', {
+      headers: { 'Content-Type': 'application/json', Origin: baseURL! },
+      data: { query: SEARCH('EDIT') },
+    });
+
+    const body = await response.json();
+    expect(body.data.search.results.hits).toEqual([]);
+  });
+
+  test('returns EDIT results to an authenticated editor', async ({ playwright, baseURL }) => {
+    // Send Authorization EXPLICITLY rather than via Playwright's `httpCredentials`. Those are only
+    // sent in response to a 401 challenge, and Jahia's GraphQL endpoint never challenges — it answers
+    // 200 with an empty result set — so the credentials would never leave the client.
+    const authorization =
+      'Basic ' +
+      Buffer.from(`root:${process.env.SUPER_USER_PASSWORD ?? 'root1234'}`).toString('base64');
+
+    // A separate context so the guest tests above stay unauthenticated.
+    const context = await playwright.request.newContext({ baseURL });
+    const response = await context.post('/modules/graphql', {
+      headers: { 'Content-Type': 'application/json', Origin: baseURL!, authorization },
+      data: { query: SEARCH('EDIT') },
+    });
+
+    const body = await response.json();
+    expect(body.errors, `unexpected errors: ${JSON.stringify(body.errors)}`).toBeUndefined();
+    // EDIT sees at least everything LIVE does, plus anything unpublished.
+    expect(body.data.search.results.totalHits).toBeGreaterThanOrEqual(TOTAL_RESULTS);
+    expect(body.data.search.results.hits.length).toBeGreaterThan(0);
+
+    await context.dispose();
+  });
+
+  test('rejects a request with no Origin header', async ({ playwright, baseURL }) => {
+    // Pinned deliberately: this is the single most confusing failure mode when writing fixtures
+    // against Jahia's GraphQL endpoint, and the error text points nowhere near the cause.
+    const context = await playwright.request.newContext({ baseURL });
+    const response = await context.post('/modules/graphql', {
+      headers: { 'Content-Type': 'application/json' },
+      data: { query: SEARCH('LIVE') },
+    });
+
+    const body = await response.json();
+    expect(body.errors?.[0]?.message).toBe('Permission denied');
+    expect(body.errors?.[0]?.extensions?.classification).toBe('GqlAccessDeniedException');
+
+    await context.dispose();
+  });
+});

--- a/tests/e2e/facets.spec.ts
+++ b/tests/e2e/facets.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import { FACETS, LABELS, NO_RESULTS_MESSAGE, TOTAL_RESULTS } from '../support/expected.js';
+
+/** The standard (checkbox) facets, the conditional Author facet, and the date-range facet. */
+test.describe('facets', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+
+  test('renders exactly the facets that have values', async () => {
+    await expect(search.facetTitles).toHaveText(
+      // CSS uppercases the legends, so compare case-insensitively.
+      LABELS.en.facetTitles.map((t) => new RegExp(`^${t}$`, 'i')),
+    );
+  });
+
+  test('does not render the Author facet until a Last modified filter is active', async () => {
+    // SearchView declares jcr:lastModifiedBy in `conditionalFacets`, gated on a jcr:lastModified
+    // filter being present. Digitall's content IS authored (every card shows "root"), so the facet's
+    // absence demonstrates the condition rather than missing data.
+    await expect(search.facet(/^author$/i)).toHaveCount(0);
+
+    // Requesting it is the observable effect: after selecting a date range, the outgoing search must
+    // ask for the lastModifiedBy facet. Asserting on the request rather than on rendered options
+    // matters because every range matches 0 documents on Digitall (content dates from 2016), so an
+    // empty result set would render no options either way.
+    const requested = search.page.waitForRequest(
+      (r) =>
+        r.url().includes('/modules/graphql') &&
+        r.method() === 'POST' &&
+        (r.postData() ?? '').includes('jcr:lastModifiedBy'),
+    );
+    await search.toggleFacetOption(/last modified/i, 'Last Week');
+    await expect(await requested).toBeTruthy();
+  });
+
+  test('never renders the Keywords facet, which has no values in Digitall', async () => {
+    await expect(search.facet(/^keywords$/i)).toHaveCount(0);
+  });
+
+  test.describe('tags facet', () => {
+    test('lists each tag with its document count', async () => {
+      for (const { value, count } of FACETS.tags) {
+        await expect(search.facetOption(/^tags$/i, value)).toBeVisible();
+        await expect(search.facetOptionCount(/^tags$/i, value)).toHaveText(String(count));
+      }
+    });
+
+    test('selecting a tag filters the results to that tag', async () => {
+      const { value, count } = FACETS.tags[0];
+
+      await search.toggleFacetOption(/^tags$/i, value);
+
+      // The facet count is a promise about the filtered total; hold the module to it.
+      await expect(search.pagingInfo).toHaveText(`Showing 1 - ${count} out of ${count}`);
+      await expect(search.results).toHaveCount(count);
+    });
+
+    test('records the selected tag in the URL', async () => {
+      const { value } = FACETS.tags[0];
+      await search.toggleFacetOption(/^tags$/i, value);
+
+      await expect(async () => {
+        const params = search.urlParams();
+        expect(params.get('filters[0][field]')).toBe('jcr:tags');
+        expect(params.get('filters[0][values][0]')).toBe(value);
+        expect(params.get('filters[0][type]')).toBe('all');
+      }).toPass();
+    });
+
+    test('deselecting a tag restores the full result set', async () => {
+      const { value, count } = FACETS.tags[0];
+
+      await search.toggleFacetOption(/^tags$/i, value);
+      await expect(search.pagingInfo).toContainText(`out of ${count}`);
+
+      await search.toggleFacetOption(/^tags$/i, value);
+      await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+      await expect(async () => {
+        expect(search.urlParams().get('filters[0][field]')).toBeNull();
+      }).toPass();
+    });
+
+    test('reflects selection in the checkbox state', async () => {
+      const { value } = FACETS.tags[0];
+      const checkbox = search.facetOption(/^tags$/i, value).locator('input[type="checkbox"]');
+
+      await expect(checkbox).not.toBeChecked();
+      await search.toggleFacetOption(/^tags$/i, value);
+      await expect(checkbox).toBeChecked();
+    });
+  });
+
+  test.describe('last modified date-range facet', () => {
+    test('offers the five configured ranges, in order, with translated labels', async () => {
+      const options = search
+        .facet(/last modified/i)
+        .locator('.sui-multi-checkbox-facet__input-text');
+      await expect(options).toHaveText([...FACETS.lastModifiedRanges]);
+    });
+
+    test('every range is empty, because Digitall content predates all of them', async () => {
+      for (const range of FACETS.lastModifiedRanges) {
+        await expect(search.facetOptionCount(/last modified/i, range)).toHaveText('0');
+      }
+    });
+
+    test('selecting a range applies a real filter and empties the results', async () => {
+      // Proves the date_range filter is genuinely applied rather than ignored: the ranges match
+      // nothing, so choosing one must produce the empty state.
+      await search.toggleFacetOption(/last modified/i, 'Last Week');
+
+      await expect(search.app).toContainText(NO_RESULTS_MESSAGE);
+      await expect(search.results).toHaveCount(0);
+      await expect(async () => {
+        expect(search.urlParams().get('filters[0][field]')).toBe('jcr:lastModified');
+      }).toPass();
+    });
+  });
+
+  test('combining a tag filter with a query narrows further', async () => {
+    const { value, count } = FACETS.tags[0];
+    await search.toggleFacetOption(/^tags$/i, value);
+    await expect(search.pagingInfo).toContainText(`out of ${count}`);
+
+    await search.search('digitall');
+    // Both constraints apply, so the total can only shrink or stay equal — never grow.
+    await expect(async () => {
+      const total = Number((await search.pagingInfo.innerText()).match(/out of (\d+)/)![1]);
+      expect(total).toBeLessThanOrEqual(count);
+    }).toPass();
+  });
+});

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import {
+  LABELS,
+  NO_RESULTS_MESSAGE,
+  NO_MATCH_QUERY,
+  PAGES,
+  TOTAL_RESULTS,
+  type Language,
+} from '../support/expected.js';
+
+/**
+ * Internationalisation, as it actually behaves.
+ *
+ * The JSP hands the app `language` (the content locale) and the app calls
+ * `i18n.changeLanguage(context.language)`, so the UI chrome is supposed to follow the page language.
+ *
+ * ⚠ THREE KNOWN BUGS ARE PINNED HERE ON PURPOSE. They are current behaviour, and the point of this
+ * suite is that the migration must not change behaviour silently — including broken behaviour. Each
+ * is marked BUG below. When one is deliberately fixed, the corresponding assertion should be
+ * inverted in the same commit, so the change is visible in review.
+ */
+test.describe('i18n', () => {
+  for (const language of ['en', 'fr'] as Language[]) {
+    test(`translates the UI chrome into ${language}`, async ({ page }) => {
+      const search = new SearchPage(page);
+      await search.goto(language);
+      const labels = LABELS[language];
+
+      await expect(search.input).toHaveAttribute('placeholder', labels.placeholder);
+      await expect(search.submitButton).toHaveValue(labels.submit);
+      await expect(search.sortLabel).toHaveText(new RegExp(`^${labels.sortBy}$`, 'i'));
+      await expect(search.pageSizeLabel).toHaveText(labels.show);
+      await expect(search.pagingInfo).toHaveText(labels.pagingInfoAll);
+      await expect(search.facetTitles).toHaveText(
+        labels.facetTitles.map((t) => new RegExp(`^${t}$`, 'i')),
+      );
+    });
+  }
+
+  test('BUG: the German page shows English chrome, because de.json is never registered', async ({
+    page,
+  }) => {
+    // i18n/resources.js imports only en and fr. i18n/de.json exists and is complete ("Kategorien",
+    // "Sortieren nach", "Zeigen", …) but is never added to the bundle, so i18next falls back to en
+    // (fallbackLng: 'en'). Fixing it is a one-line change to resources.js.
+    const search = new SearchPage(page);
+    await search.goto('de');
+
+    await expect(search.input).toHaveAttribute('placeholder', 'Search');
+    await expect(search.sortLabel).toHaveText(/^Sort by$/i);
+    await expect(search.pageSizeLabel).toHaveText('Show');
+    await expect(search.facetTitles).toHaveText([/^Categories$/i, /^Tags$/i, /^Last modified$/i]);
+
+    // Explicitly NOT the German strings that de.json already provides.
+    await expect(search.sortLabel).not.toHaveText(/Sortieren nach/i);
+    await expect(search.facetTitles.first()).not.toHaveText(/Kategorien/i);
+  });
+
+  test('search results follow the page language, even when the chrome does not', async ({
+    page,
+  }) => {
+    // The content side is wired correctly: the connector passes the content locale, so German pages
+    // return German documents. Only the UI chrome falls back.
+    const search = new SearchPage(page);
+
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+    const english = await search.resultTitles.allInnerTexts();
+
+    await search.goto('de');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+    const german = await search.resultTitles.allInnerTexts();
+
+    expect(german).not.toEqual(english);
+    // Digitall's German home page article.
+    expect(german.join(' | ')).toContain('Digitall wurde gegründet');
+  });
+
+  test('every language indexes the same number of documents', async ({ page }) => {
+    const search = new SearchPage(page);
+    for (const language of Object.keys(PAGES) as Language[]) {
+      await search.goto(language);
+      // Compare against the language's own phrasing — French reads "Affiche 1 - 20 sur 61", so
+      // asserting the English "out of 61" would fail on a correctly translated page.
+      await expect(search.pagingInfo).toHaveText(LABELS[language].pagingInfoAll);
+    }
+  });
+
+  test('BUG: dates are always formatted in French, whatever the page language', async ({ page }) => {
+    // app/index.js does `import 'moment/locale/fr'`, which registers the locale AND makes it moment's
+    // global default. The intended correction, `moment().locale(context.language)`, sets the locale on
+    // a throwaway instance instead of globally (that would be `moment.locale(...)`), so every date
+    // renders with French month names regardless of language.
+    const search = new SearchPage(page);
+    await search.goto('en');
+
+    const excerpt = search.results.first().locator('.excerpt');
+    // French abbreviated months: janv. févr. mars avr. mai juin juil. août sept. oct. nov. déc.
+    await expect(excerpt).toContainText(
+      /\d{1,2}\s(janv\.|févr\.|mars|avr\.|mai|juin|juil\.|août|sept\.|oct\.|nov\.|déc\.)\s\d{4}/,
+    );
+    // The surrounding label IS translated, which is what makes the mismatch visible: an English
+    // "created at" next to a French date.
+    await expect(excerpt).toContainText(LABELS.en.createdAt);
+  });
+
+  test('BUG: the empty-results message is never translated', async ({ page }) => {
+    // SearchView passes a literal `fallbackView="Nothing was found"` instead of using the
+    // `search.fallbackMsg` key, which exists in all three bundles ("Aucun résultat ne correspond à
+    // votre recherche", "Es wurde nichts gefunden").
+    const search = new SearchPage(page);
+    await search.goto('fr');
+    await search.search(NO_MATCH_QUERY);
+
+    await expect(search.app).toContainText(NO_RESULTS_MESSAGE);
+    await expect(search.app).not.toContainText('Aucun résultat');
+  });
+});

--- a/tests/e2e/results.spec.ts
+++ b/tests/e2e/results.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import { KNOWN_QUERY, LABELS } from '../support/expected.js';
+
+/**
+ * The anatomy of a result card, as rendered by the custom ResultView.
+ *
+ * ResultView is one of the pieces most likely to drift during the migration, because it is entirely
+ * bespoke: title, node-type label, a breadcrumb built from the URL, an icon chosen per node type, a
+ * date/author line, and an HTML excerpt.
+ */
+test.describe('result cards', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+  });
+
+  test('each card links to the content it found', async () => {
+    const first = search.results.first();
+    await expect(first).toBeVisible();
+
+    // The whole card is wrapped in a single anchor.
+    const link = first.locator('a').first();
+    const href = await link.getAttribute('href');
+    expect(href).toMatch(/^\/sites\/digitall\/.+\.html$/);
+
+    // The title is an h3 inside that anchor and must not be empty.
+    await expect(first.locator('h3.title')).not.toBeEmpty();
+  });
+
+  test('shows a human-readable node-type label', async () => {
+    // getNodeTypeKey maps the JCR node type through config/types.js to an i18n key, falling back to
+    // DEFAULT -> "Content". Digitall's content is mostly jnt:news / jnt:page, none of which appear in
+    // config/types.js, so "Content" is the expected label here.
+    const labels = await search.app.locator('.result .search-content > span').allInnerTexts();
+    expect(labels.length).toBeGreaterThan(0);
+    expect(labels.every((l) => l.trim().length > 0)).toBe(true);
+    expect(labels).toContain('Content');
+  });
+
+  test('renders a breadcrumb derived from the content path', async () => {
+    // getURLStream turns /sites/digitall/home/about/....html into "sites > digitall > home > about".
+    const cite = search.results.first().locator('cite');
+    await expect(cite).toContainText('sites');
+    await expect(cite).toContainText('>');
+    await expect(cite).toContainText('digitall');
+    // The .html suffix is stripped.
+    await expect(cite).not.toContainText('.html');
+  });
+
+  test('shows the modification date, the created-at hint and the author', async () => {
+    const excerpt = search.results.first().locator('.excerpt');
+    await expect(excerpt).toBeVisible();
+
+    // DateComponent renders "<modified> (created at <created>) — <author> —".
+    await expect(excerpt).toContainText(LABELS.en.createdAt);
+    await expect(excerpt.locator('small')).toContainText(LABELS.en.createdAt);
+    // Digitall's demo content is authored by root.
+    await expect(excerpt).toContainText('root');
+  });
+
+  test('renders the excerpt as HTML, with search terms highlighted', async () => {
+    await search.search(KNOWN_QUERY.term);
+    await expect(search.results.first()).toBeVisible();
+
+    // Augmented Search wraps matches in <em> (the configured highlighter tags) and ResultView injects
+    // the snippet with dangerouslySetInnerHTML, so the markup must survive as real elements.
+    const highlighted = search.app.locator('.result .excerpt em');
+    await expect(highlighted.first()).toBeVisible();
+    // The highlighted text is the STEMMED match, not the term typed: searching "movies" highlights
+    // "movie", because the index applies the English stemmer configured in augmented-search.
+    await expect(highlighted.first()).toContainText(/movie/i);
+  });
+
+  test('gives every card an icon', async () => {
+    // getIcon always returns a react-icons SVG, defaulting to a file icon for unmapped types.
+    const cards = await search.results.count();
+    await expect(search.app.locator('.result .header svg')).toHaveCount(cards);
+  });
+
+  test('colours the card by node type', async () => {
+    // getNodeTypeColor falls back to var(--color-default) for types absent from config/types.js.
+    const style = await search.results.first().locator('a').first().getAttribute('style');
+    expect(style).toContain('color:');
+    expect(style).toMatch(/var\(--color-/);
+  });
+});

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import {
+  DEFAULT_PAGE_SIZE,
+  KNOWN_QUERY,
+  NO_MATCH_QUERY,
+  NO_RESULTS_MESSAGE,
+  TOTAL_RESULTS,
+} from '../support/expected.js';
+
+/** Core search behaviour: what the component does on load, while typing, and when nothing matches. */
+test.describe('search', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+  });
+
+  test('searches on initial load, without the user doing anything', async () => {
+    // SearchProvider is configured with alwaysSearchOnInitialLoad: true, so an empty query runs
+    // immediately and the component is never in an empty state on arrival.
+    await expect(search.pagingInfo).toHaveText(
+      `Showing 1 - ${DEFAULT_PAGE_SIZE} out of ${TOTAL_RESULTS}`,
+    );
+    await expect(search.results).toHaveCount(DEFAULT_PAGE_SIZE);
+    await expect(search.input).toHaveValue('');
+  });
+
+  test('a free-text query narrows the results', async () => {
+    await search.search(KNOWN_QUERY.term);
+
+    await expect(search.pagingInfo).toContainText(`out of ${KNOWN_QUERY.hits}`);
+    // PagingInfo appends the term it searched for.
+    await expect(search.pagingInfo).toContainText(`for: ${KNOWN_QUERY.term}`);
+    await expect(search.results.first()).toBeVisible();
+  });
+
+  test('searches as you type, with no submit', async () => {
+    // debounceLength is 0 and searchAsYouType is on, so each change triggers a search. Typing a
+    // longer, more specific term must strictly reduce the result count.
+    await search.search('a');
+    await expect(search.pagingInfo).toBeVisible();
+    const broad = await search.pagingInfo.innerText();
+
+    await search.search('annual filings');
+    await expect(search.pagingInfo).not.toHaveText(broad);
+
+    const totalOf = (text: string) => Number(text.match(/out of (\d+)/)![1]);
+    expect(totalOf(await search.pagingInfo.innerText()))
+      .toBeLessThan(totalOf(broad));
+  });
+
+  test('the submit button is present and labelled', async () => {
+    // SearchInput renders the button as an <input type="submit"> whose value carries the label.
+    await expect(search.submitButton).toHaveValue('Search');
+  });
+
+  test('shows the empty state when nothing matches, and hides the result chrome', async () => {
+    await search.search(NO_MATCH_QUERY);
+
+    await expect(search.app).toContainText(NO_RESULTS_MESSAGE);
+    await expect(search.results).toHaveCount(0);
+    // ViewWrapper renders a fallback for the header and footer regions too, so paging info,
+    // results-per-page and the pager all disappear rather than showing "0 - 0 out of 0".
+    await expect(search.pagingInfo).toHaveCount(0);
+    await expect(search.pageSizeLabel).toHaveCount(0);
+    await expect(search.pagination).toHaveCount(0);
+  });
+
+  test('recovers from the empty state when the query is corrected', async () => {
+    await search.search(NO_MATCH_QUERY);
+    await expect(search.app).toContainText(NO_RESULTS_MESSAGE);
+
+    await search.search(KNOWN_QUERY.term);
+    await expect(search.pagingInfo).toContainText(`out of ${KNOWN_QUERY.hits}`);
+    await expect(search.app).not.toContainText(NO_RESULTS_MESSAGE);
+  });
+
+  test('survives special characters without breaking the query', async () => {
+    // The connector escapes the term into a GraphQL string; these inputs used to break it, and there
+    // are regression snapshots for them in the connector's own suite.
+    for (const term of ['digitall"', 'digitall\\', 'a & b', "quote'", 'slash/es', 'colon:value']) {
+      await search.search(term);
+      // The assertion is that the component keeps working — either results or the empty state, never
+      // a crash that unmounts the app.
+      await expect(search.input).toHaveValue(term);
+      await expect(search.app).toBeVisible();
+      await expect(async () => {
+        const hasResults = (await search.results.count()) > 0;
+        const hasEmptyState = (await search.app.innerText()).includes(NO_RESULTS_MESSAGE);
+        expect(hasResults || hasEmptyState).toBe(true);
+      }).toPass();
+    }
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Smoke test: is the environment actually wired up end to end?
+ *
+ * This is intentionally shallow — it proves Jahia, Augmented Search, Elasticsearch and the module
+ * are all talking to each other. The behavioural suite that pins down search, facets, paging,
+ * sorting and i18n comes on top of this.
+ */
+
+const HOME = '/sites/digitall/home.html';
+
+test.describe('augmented-search-ui smoke', () => {
+  test('the search component renders on the Digitall home page', async ({ page }) => {
+    await page.goto(HOME);
+
+    // The module mounts into a container id'd by the content node's uuid.
+    const container = page.locator('[id^="augmentedSearchUIApp_"]');
+    await expect(container).toBeAttached();
+
+    // A search input appears only once the React app has mounted and replaced "Loading...".
+    await expect(container.locator('input[type="text"], input[type="search"]').first())
+      .toBeVisible();
+  });
+
+  test('a search returns results from Augmented Search', async ({ page }) => {
+    await page.goto(HOME);
+
+    const container = page.locator('[id^="augmentedSearchUIApp_"]');
+    const input = container.locator('input[type="text"], input[type="search"]').first();
+    await expect(input).toBeVisible();
+
+    // Wait for the search request itself rather than a fixed timeout: the module queries Jahia's
+    // GraphQL endpoint, so a response carrying search data is the real signal.
+    const searchResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('/modules/graphql') &&
+        response.request().method() === 'POST' &&
+        response.ok(),
+    );
+
+    await input.fill('digitall');
+    await searchResponse;
+
+    // Assert on a rendered result, not on the response body — that is what a user actually sees.
+    await expect(container.getByRole('link').first()).toBeVisible();
+  });
+
+  test('Augmented Search answers the GraphQL search query', async ({ request }) => {
+    // A direct API check, so a UI regression and a broken index give different failures.
+    const response = await request.post('/modules/graphql', {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        query: `query { search(q: "digitall", workspace: LIVE) {
+                  results(size: 5) { totalHits hits { displayableName link } } } }`,
+      },
+    });
+
+    expect(response.ok()).toBeTruthy();
+    const body = await response.json();
+    expect(body.errors, `GraphQL returned errors: ${JSON.stringify(body.errors)}`).toBeUndefined();
+    expect(body.data.search.results.totalHits).toBeGreaterThan(0);
+  });
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -10,24 +10,35 @@ import { test, expect } from '@playwright/test';
 
 const HOME = '/sites/digitall/home.html';
 
+/**
+ * The module mounts into a container id'd by the content node's uuid.
+ *
+ * Locate the search field by ROLE, not by `input[type=...]`: Elastic's SearchBox renders
+ *   <input aria-autocomplete="list" id="downshift-0-input" placeholder="Search" class="sui-search-box__text-input">
+ * with **no type attribute**, so `input[type="text"]` matches nothing (a CSS attribute selector
+ * needs the attribute to be present). Avoid comma-separated CSS in a chained locator too —
+ * Playwright splits it at the top level, so the second alternative escapes the container scope.
+ */
+const searchApp = (page: import('@playwright/test').Page) =>
+  page.locator('[id^="augmentedSearchUIApp_"]');
+const searchInput = (page: import('@playwright/test').Page) =>
+  searchApp(page).getByRole('textbox').first();
+
 test.describe('augmented-search-ui smoke', () => {
   test('the search component renders on the Digitall home page', async ({ page }) => {
     await page.goto(HOME);
 
-    // The module mounts into a container id'd by the content node's uuid.
-    const container = page.locator('[id^="augmentedSearchUIApp_"]');
-    await expect(container).toBeAttached();
+    await expect(searchApp(page)).toBeAttached();
 
-    // A search input appears only once the React app has mounted and replaced "Loading...".
-    await expect(container.locator('input[type="text"], input[type="search"]').first())
-      .toBeVisible();
+    // The input exists only once the React app has mounted and replaced "Loading...".
+    await expect(searchInput(page)).toBeVisible();
   });
 
   test('a search returns results from Augmented Search', async ({ page }) => {
     await page.goto(HOME);
 
-    const container = page.locator('[id^="augmentedSearchUIApp_"]');
-    const input = container.locator('input[type="text"], input[type="search"]').first();
+    const container = searchApp(page);
+    const input = searchInput(page);
     await expect(input).toBeVisible();
 
     // Wait for the search request itself rather than a fixed timeout: the module queries Jahia's
@@ -46,10 +57,15 @@ test.describe('augmented-search-ui smoke', () => {
     await expect(container.getByRole('link').first()).toBeVisible();
   });
 
-  test('Augmented Search answers the GraphQL search query', async ({ request }) => {
+  test('Augmented Search answers the GraphQL search query', async ({ request, baseURL }) => {
     // A direct API check, so a UI regression and a broken index give different failures.
+    //
+    // The Origin header is REQUIRED and must match the Jahia origin. Browsers set it automatically
+    // on POST, but Playwright's request context does not — and without it Jahia treats the call as
+    // unauthenticated and answers `GqlAccessDeniedException: Permission denied`, which reads like a
+    // permissions problem rather than a missing header.
     const response = await request.post('/modules/graphql', {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', Origin: baseURL! },
       data: {
         query: `query { search(q: "digitall", workspace: LIVE) {
                   results(size: 5) { totalHits hits { displayableName link } } } }`,

--- a/tests/e2e/sorting-and-paging.spec.ts
+++ b/tests/e2e/sorting-and-paging.spec.ts
@@ -1,0 +1,201 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import {
+  DEFAULT_PAGE_SIZE,
+  FIRST_BY_CREATED,
+  FIRST_BY_TITLE,
+  LABELS,
+  PAGE_SIZE_OPTIONS,
+  SORT_OPTIONS,
+  TOTAL_RESULTS,
+} from '../support/expected.js';
+
+/** Sorting, paging, and the two custom views that surround the results (PagingInfo, ResultsPerPage). */
+test.describe('sorting', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+
+  test('defaults to relevance', async () => {
+    await expect(search.sortLabel).toHaveText(new RegExp(`^${LABELS.en.sortBy}$`, 'i'));
+    await expect(search.selectedValueOf('sorting')).toHaveText(SORT_OPTIONS.relevance.label);
+  });
+
+  test('offers the four configured options, in order', async () => {
+    await search.app.locator('.sui-sorting .sui-select__control').click();
+    await expect(search.page.locator('.sui-select__option')).toHaveText([
+      SORT_OPTIONS.created.label,
+      SORT_OPTIONS.modified.label,
+      SORT_OPTIONS.relevance.label,
+      SORT_OPTIONS.title.label,
+    ]);
+  });
+
+  test('sorting by title reorders the results and records the field in the URL', async () => {
+    const firstBefore = await search.resultTitles.first().innerText();
+
+    await search.sortBy(SORT_OPTIONS.title.label);
+
+    await expect(search.resultTitles.first()).toHaveText(FIRST_BY_TITLE);
+    expect(await search.resultTitles.first().innerText()).not.toBe(firstBefore);
+    await expect(async () => {
+      const params = search.urlParams();
+      expect(params.get('sort-field')).toBe(SORT_OPTIONS.title.field);
+      expect(params.get('sort-direction')).toBe(SORT_OPTIONS.title.direction);
+    }).toPass();
+  });
+
+  test('sorting by creation date reorders again, descending', async () => {
+    await search.sortBy(SORT_OPTIONS.created.label);
+
+    await expect(search.resultTitles.first()).toHaveText(FIRST_BY_CREATED);
+    await expect(async () => {
+      const params = search.urlParams();
+      expect(params.get('sort-field')).toBe(SORT_OPTIONS.created.field);
+      expect(params.get('sort-direction')).toBe(SORT_OPTIONS.created.direction);
+    }).toPass();
+  });
+
+  test('returning to relevance clears the sort from the URL', async () => {
+    await search.sortBy(SORT_OPTIONS.title.label);
+    await expect(async () => {
+      expect(search.urlParams().get('sort-field')).toBe(SORT_OPTIONS.title.field);
+    }).toPass();
+
+    // Relevance is configured with empty field and direction, so Search UI drops the parameters.
+    await search.sortBy(SORT_OPTIONS.relevance.label);
+    await expect(async () => {
+      expect(search.urlParams().get('sort-field')).toBeFalsy();
+    }).toPass();
+  });
+
+  test('sorting does not change how many results match', async () => {
+    await search.sortBy(SORT_OPTIONS.title.label);
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+});
+
+test.describe('paging', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+
+  test('PagingInfo reports the window and the total', async () => {
+    // The custom PagingInfo view composes translated fragments around <strong> elements.
+    await expect(search.pagingInfo).toHaveText(
+      `Showing 1 - ${DEFAULT_PAGE_SIZE} out of ${TOTAL_RESULTS}`,
+    );
+    await expect(search.pagingInfo.locator('strong').first()).toHaveText(
+      `1 - ${DEFAULT_PAGE_SIZE}`,
+    );
+    await expect(search.pagingInfo.locator('strong').nth(1)).toHaveText(String(TOTAL_RESULTS));
+  });
+
+  test('PagingInfo appends the search term only when there is one', async () => {
+    await expect(search.pagingInfo).not.toContainText('for:');
+
+    await search.search('movies');
+    await expect(search.pagingInfo).toContainText('for: movies');
+    // The term is emphasised.
+    await expect(search.pagingInfo.locator('em')).toHaveText('movies');
+  });
+
+  test('paginates the full result set', async () => {
+    const expectedPages = Math.ceil(TOTAL_RESULTS / DEFAULT_PAGE_SIZE);
+    await expect(search.app.locator('li.rc-pagination-item')).toHaveCount(expectedPages);
+    await expect(search.activePage).toHaveText('1');
+  });
+
+  test('moving to page two advances the window and records it in the URL', async () => {
+    await search.gotoPage(2);
+
+    await expect(search.pagingInfo).toHaveText(
+      `Showing ${DEFAULT_PAGE_SIZE + 1} - ${DEFAULT_PAGE_SIZE * 2} out of ${TOTAL_RESULTS}`,
+    );
+    await expect(search.activePage).toHaveText('2');
+    await expect(async () => {
+      expect(search.urlParams().get('current')).toBe('n_2_n');
+    }).toPass();
+  });
+
+  test('the last page holds the remainder', async () => {
+    const lastPage = Math.ceil(TOTAL_RESULTS / DEFAULT_PAGE_SIZE);
+    const remainder = TOTAL_RESULTS % DEFAULT_PAGE_SIZE || DEFAULT_PAGE_SIZE;
+
+    await search.gotoPage(lastPage);
+
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+    await expect(search.results).toHaveCount(remainder);
+  });
+
+  test('pages hold disjoint sets of documents', async () => {
+    // Compare LINKS, not titles. Digitall contains several documents that share a display name (a
+    // handful of person records are all called "Taber", "Taylor", …), so overlapping titles across
+    // pages is expected and says nothing about paging. The href is the identity.
+    const hrefs = () =>
+      search.app
+        .locator('.result a')
+        .evaluateAll((els) => els.map((e) => (e as HTMLAnchorElement).getAttribute('href')));
+
+    const firstPage = await hrefs();
+
+    await search.gotoPage(2);
+    // The pager marks page 2 active immediately, while the results are still the previous page's.
+    // Wait for the RESULT WINDOW to move, not just the pager, or this compares page 1 against itself.
+    await expect(search.pagingInfo).toHaveText(
+      `Showing ${DEFAULT_PAGE_SIZE + 1} - ${DEFAULT_PAGE_SIZE * 2} out of ${TOTAL_RESULTS}`,
+    );
+    const secondPage = await hrefs();
+
+    expect(secondPage).not.toEqual(firstPage);
+    // No document may appear on both pages — that would mean an unstable sort.
+    expect(secondPage.filter((h) => firstPage.includes(h))).toEqual([]);
+  });
+});
+
+test.describe('results per page', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+
+  test('is labelled and defaults to 20', async () => {
+    await expect(search.pageSizeLabel).toHaveText(LABELS.en.show);
+    await expect(search.selectedValueOf('results-per-page')).toHaveText(
+      String(DEFAULT_PAGE_SIZE),
+    );
+  });
+
+  test('offers 20, 40 and 60', async () => {
+    await search.app.locator('.sui-results-per-page .sui-select__control').click();
+    await expect(search.page.locator('.sui-select__option')).toHaveText([...PAGE_SIZE_OPTIONS]);
+  });
+
+  test('changing the page size resizes the result window', async () => {
+    await search.setPageSize('40');
+
+    await expect(search.pagingInfo).toHaveText(`Showing 1 - 40 out of ${TOTAL_RESULTS}`);
+    await expect(search.results).toHaveCount(40);
+    await expect(async () => {
+      expect(search.urlParams().get('size')).toBe('n_40_n');
+    }).toPass();
+  });
+
+  test('a larger page size reduces the number of pages', async () => {
+    await search.setPageSize('60');
+    await expect(search.results).toHaveCount(60);
+    // 61 results at 60 per page is 2 pages.
+    await expect(search.app.locator('li.rc-pagination-item')).toHaveCount(2);
+  });
+});

--- a/tests/e2e/tree-facet.spec.ts
+++ b/tests/e2e/tree-facet.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import { FACETS, TOTAL_RESULTS } from '../support/expected.js';
+
+/**
+ * The Categories facet — the module's most bespoke component.
+ *
+ * TreeFacet/Tree/TreeNode replace Search UI's checkbox view with a hierarchical tree over
+ * `jgql:categories_path`, driving its own GraphQL query to lazy-load children on expand. It is the
+ * piece most at risk in the migration, and the least like anything Search UI provides.
+ *
+ * Note on selectors: TreeNode is built with styled-components, so its classes are build-specific
+ * hashes. Everything here goes through roles and text instead (see SearchPage.treeNode).
+ */
+test.describe('categories tree facet', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+
+  test('renders inside a labelled fieldset, not the checkbox view', async () => {
+    const categories = search.facet(/^categories$/i);
+    await expect(categories).toBeVisible();
+    await expect(categories.locator('legend.sui-facet__title')).toHaveText(/^categories$/i);
+
+    // TreeFacet reuses Search UI's container class but renders tree nodes rather than checkboxes.
+    await expect(categories.locator('.sui-multi-checkbox-facet')).toBeVisible();
+    await expect(categories.locator('input[type="checkbox"]')).toHaveCount(0);
+  });
+
+  test('lists each category with its document count', async () => {
+    const { value, count } = FACETS.categories[0];
+    const node = search.treeNode(value);
+
+    await expect(node).toBeVisible();
+    // TreeNode puts the count in a sibling span within the same row.
+    await expect(search.facet(/^categories$/i)).toContainText(String(count));
+  });
+
+  test('selecting a category filters the results', async () => {
+    const { value, count } = FACETS.categories[0];
+
+    await search.treeNode(value).click();
+
+    await expect(search.pagingInfo).toHaveText(`Showing 1 - ${count} out of ${count}`);
+    await expect(search.results).toHaveCount(count);
+  });
+
+  test('records the category filter in the URL as a categories_path filter', async () => {
+    const { value } = FACETS.categories[0];
+    await search.treeNode(value).click();
+
+    await expect(async () => {
+      const params = search.urlParams();
+      expect(params.get('filters[0][field]')).toBe('jgql:categories_path');
+      // The tree filters on the category's PATH, not its display name, so assert a non-empty value
+      // rather than the label.
+      expect(params.get('filters[0][values][0]')).toBeTruthy();
+      // SearchView configures this facet with filterType="any".
+      expect(params.get('filters[0][type]')).toBe('any');
+    }).toPass();
+  });
+
+  test('clicking a selected category deselects it and restores the results', async () => {
+    const { value, count } = FACETS.categories[0];
+
+    await search.treeNode(value).click();
+    await expect(search.pagingInfo).toContainText(`out of ${count}`);
+
+    // TreeNode toggles: onRemove when already selected. This is hand-rolled state, not Search UI's.
+    await search.treeNode(value).click();
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+    await expect(async () => {
+      expect(search.urlParams().get('filters[0][field]')).toBeNull();
+    }).toPass();
+  });
+
+  test('marks the selected category with an underline', async () => {
+    // Selection state is conveyed ONLY through `text-decoration: underline` on the title span — there
+    // is no class, no aria-pressed, no checkbox. Worth pinning: it is both the sole visual signal and
+    // an accessibility gap the migration could improve.
+    const { value } = FACETS.categories[0];
+    const node = search.treeNode(value);
+
+    await expect(node).toHaveCSS('text-decoration-line', 'none');
+    await node.click();
+    await expect(node).toHaveCSS('text-decoration-line', 'underline');
+  });
+
+  test('shows no expand control for a leaf category', async () => {
+    // "Annual Filings" has no descendants in Digitall, so TreeNode renders an empty icon slot and no
+    // chevron. If a future dataset adds children, this test is the signal to add an expansion test.
+    const categories = search.facet(/^categories$/i);
+    await expect(categories.locator('svg')).toHaveCount(0);
+  });
+
+  test('does not offer the "+ More" button below the configured limit', async () => {
+    // The facet is configured with show={50}; Digitall has a single category, so Search UI reports
+    // showMore=false and TreeFacet renders no button.
+    await expect(search.facet(/^categories$/i).locator('button.sui-facet-view-more')).toHaveCount(0);
+  });
+
+  test('disappears when a filter leaves no categories to offer', async () => {
+    // Selecting a tag reduces the set to documents with no category, so the facet has no options and
+    // Search UI drops it entirely. Recorded because it looks like a bug when first observed.
+    await search.toggleFacetOption(/^tags$/i, 'health');
+    await expect(search.pagingInfo).toContainText('out of 3');
+    await expect(search.facet(/^categories$/i)).toHaveCount(0);
+  });
+});

--- a/tests/e2e/url-state.spec.ts
+++ b/tests/e2e/url-state.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+import { SearchPage } from '../support/search-page.js';
+import {
+  DEFAULT_PAGE_SIZE,
+  FACETS,
+  KNOWN_QUERY,
+  SORT_OPTIONS,
+  TOTAL_RESULTS,
+} from '../support/expected.js';
+
+/**
+ * Query state in the URL.
+ *
+ * Search UI's `trackUrlState` defaults to on, so the query, page, page size, sort and filters are all
+ * mirrored into the query string. That makes search results shareable and bookmarkable, and it is
+ * behaviour a re-platform can easily lose — the state lives in the client, and an SSR-first rewrite
+ * would have to reproduce it deliberately.
+ */
+test.describe('URL query state', () => {
+  let search: SearchPage;
+
+  test.beforeEach(async ({ page }) => {
+    search = new SearchPage(page);
+  });
+
+  test('records the page size even before the user touches anything', async () => {
+    await search.goto('en');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+    await expect(async () => {
+      expect(search.urlParams().get('size')).toBe(`n_${DEFAULT_PAGE_SIZE}_n`);
+    }).toPass();
+  });
+
+  test('records the search term', async () => {
+    await search.goto('en');
+    await search.search(KNOWN_QUERY.term);
+    await expect(async () => {
+      expect(search.urlParams().get('q')).toBe(KNOWN_QUERY.term);
+    }).toPass();
+  });
+
+  test('restores a search term from a deep link', async () => {
+    await search.goto('en', `q=${KNOWN_QUERY.term}&size=n_${DEFAULT_PAGE_SIZE}_n`);
+
+    // The input is rehydrated from the URL, not just the results.
+    await expect(search.input).toHaveValue(KNOWN_QUERY.term);
+    await expect(search.pagingInfo).toContainText(`out of ${KNOWN_QUERY.hits}`);
+    await expect(search.pagingInfo).toContainText(`for: ${KNOWN_QUERY.term}`);
+  });
+
+  test('restores the page number from a deep link', async () => {
+    await search.goto('en', `current=n_2_n&size=n_${DEFAULT_PAGE_SIZE}_n`);
+
+    await expect(search.activePage).toHaveText('2');
+    await expect(search.pagingInfo).toHaveText(
+      `Showing ${DEFAULT_PAGE_SIZE + 1} - ${DEFAULT_PAGE_SIZE * 2} out of ${TOTAL_RESULTS}`,
+    );
+  });
+
+  test('restores the page size from a deep link', async () => {
+    await search.goto('en', 'size=n_40_n');
+
+    await expect(search.selectedValueOf('results-per-page')).toHaveText('40');
+    await expect(search.results).toHaveCount(40);
+  });
+
+  test('restores sorting from a deep link', async () => {
+    await search.goto(
+      'en',
+      `size=n_${DEFAULT_PAGE_SIZE}_n&sort-field=${encodeURIComponent(SORT_OPTIONS.title.field)}&sort-direction=${SORT_OPTIONS.title.direction}`,
+    );
+
+    await expect(search.selectedValueOf('sorting')).toHaveText(SORT_OPTIONS.title.label);
+  });
+
+  test('restores a facet filter from a deep link', async () => {
+    const { value, count } = FACETS.tags[0];
+    // Encode with URLSearchParams: the raw brackets and the colon in `jcr:tags` must be
+    // percent-encoded or Jahia never serves the page, and the component simply never mounts.
+    const filter = new URLSearchParams({
+      'filters[0][field]': 'jcr:tags',
+      'filters[0][values][0]': value,
+      'filters[0][type]': 'all',
+      'filters[0][persistent]': 'false',
+    }).toString();
+
+    await search.goto('en', `size=n_${DEFAULT_PAGE_SIZE}_n&${filter}`);
+
+    await expect(search.pagingInfo).toContainText(`out of ${count}`);
+    await expect(
+      search.facetOption(/^tags$/i, value).locator('input[type="checkbox"]'),
+    ).toBeChecked();
+  });
+
+  test('a full round-trip reproduces the same view', async () => {
+    // Build up state through the UI, then reload the resulting URL and expect the same thing back.
+    await search.goto('en');
+    await search.search(KNOWN_QUERY.term);
+    await expect(search.pagingInfo).toContainText(`for: ${KNOWN_QUERY.term}`);
+    await search.sortBy(SORT_OPTIONS.title.label);
+    await expect(search.selectedValueOf('sorting')).toHaveText(SORT_OPTIONS.title.label);
+    await search.setPageSize('40');
+    await expect(search.selectedValueOf('results-per-page')).toHaveText('40');
+
+    // Only capture the URL once every piece of state has actually reached it — the UI updates before
+    // the query string does, so reading it too early yields a partial URL.
+    await expect(async () => {
+      const params = search.urlParams();
+      expect(params.get('q')).toBe(KNOWN_QUERY.term);
+      expect(params.get('size')).toBe('n_40_n');
+      expect(params.get('sort-field')).toBe(SORT_OPTIONS.title.field);
+    }).toPass();
+
+    const built = search.page.url();
+    const before = await search.resultTitles.allInnerTexts();
+
+    await search.page.goto(built);
+    await search.waitUntilMounted();
+
+    await expect(search.input).toHaveValue(KNOWN_QUERY.term);
+    await expect(search.selectedValueOf('sorting')).toHaveText(SORT_OPTIONS.title.label);
+    await expect(search.selectedValueOf('results-per-page')).toHaveText('40');
+    await expect(async () => {
+      expect(await search.resultTitles.allInnerTexts()).toEqual(before);
+    }).toPass();
+  });
+
+  test('the browser back button returns to the previous search', async () => {
+    // Navigate to both states EXPLICITLY rather than typing and then going back.
+    //
+    // Search UI decides per change whether to push or replace the history entry, and the choice is
+    // timing-dependent: type quickly and the entry is replaced, so `goBack()` leaves the page
+    // altogether (to about:blank in a fresh context) and the component no longer exists. That made a
+    // type-then-back test flaky for reasons that have nothing to do with this module.
+    //
+    // Two real navigations always create two history entries, so this tests the behaviour users care
+    // about — going back restores the earlier search — deterministically.
+    await search.goto('en', `size=n_${DEFAULT_PAGE_SIZE}_n`);
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+
+    await search.goto('en', `q=${KNOWN_QUERY.term}&size=n_${DEFAULT_PAGE_SIZE}_n`);
+    await expect(search.input).toHaveValue(KNOWN_QUERY.term);
+    await expect(search.pagingInfo).toContainText(`out of ${KNOWN_QUERY.hits}`);
+
+    await search.page.goBack();
+    // The page reloads and the app remounts, so wait for the mount before asserting.
+    await search.waitUntilMounted();
+    await expect(search.input).toHaveValue('');
+    await expect(search.pagingInfo).toContainText(`out of ${TOTAL_RESULTS}`);
+  });
+});

--- a/tests/elasticsearch/Dockerfile
+++ b/tests/elasticsearch/Dockerfile
@@ -1,0 +1,27 @@
+# Elasticsearch for augmented-search — stock ES plus the analysis plugins the module needs.
+#
+# WHY this image exists instead of using stock Elasticsearch: augmented-search creates its indices
+# with analyzers that live in plugins. Without them index creation fails and the reindex job dies
+# with, e.g.
+#   [illegal_argument_exception] Custom Analyzer [fr_phrase_shingle_analyzer]
+#   failed to find tokenizer under name [icu_tokenizer]
+# — which reads like a Jahia bug but is a missing ES plugin. The module declares what it needs in
+# its own configuration (`META-INF/configurations/settings*.json`, the `requires` key):
+#
+#   analysis-icu       — icu_tokenizer, used by the DEFAULT settings.json -> always required
+#   analysis-stempel   — settings_pl.json (Polish: polish/polish_stop/polish_stem)
+#   analysis-kuromoji  — settings_ja.json (Japanese: kuromoji_tokenizer/kuromoji_stemmer)
+#
+# All three are installed so the environment works whatever site languages are used. If a future
+# augmented-search adds a language, check its settings_<lang>.json `requires` and add it here.
+#
+# Keep the ES version in step with the client augmented-search bundles: elasticsearch-connector 4.x
+# ships co.elastic.clients:elasticsearch-java 9.1.3, so a 9.1.x server.
+
+ARG ES_BASE_IMAGE=docker.elastic.co/elasticsearch/elasticsearch:9.1.3
+FROM ${ES_BASE_IMAGE}
+
+RUN elasticsearch-plugin install --batch \
+        analysis-icu \
+        analysis-stempel \
+        analysis-kuromoji

--- a/tests/index-digitall.graphql
+++ b/tests/index-digitall.graphql
@@ -1,0 +1,21 @@
+# Register the Digitall site with Augmented Search and start a full indexation.
+# Referenced by provisioning-manifest-stable.yml.
+#
+# Indexation is ASYNCHRONOUS: this returns job ids, not a finished index. The mutation succeeds even
+# when the job later fails, so callers must verify that indices actually exist
+# (GET <elasticsearch>/_cat/indices) rather than trusting this response.
+#
+# Note there is no setDbConnection call, unlike Augmented Search 3.x — the Elasticsearch connection
+# comes from the org.jahia.modules.elasticsearchConnector OSGi configuration.
+mutation {
+    admin {
+        search {
+            addSite(siteKey: "digitall")
+            startIndex(siteKeys: ["digitall"]) {
+                jobs {
+                    id
+                }
+            }
+        }
+    }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "augmented-search-ui-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "End-to-end tests for augmented-search-ui, run against a provisioned Jahia + Augmented Search environment",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui",
+    "report": "playwright show-report results/report"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.62.0"
+  }
+}

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * The environment is provisioned before Playwright starts (see provision.sh), so there is no
+ * webServer block here — the suite always runs against an already-live Jahia.
+ *
+ * JAHIA_URL defaults to the docker-compose service name; override it to run the suite from your
+ * host against a local instance:
+ *   JAHIA_URL=http://localhost:8080 npm test
+ */
+const jahiaUrl = process.env.JAHIA_URL ?? 'http://localhost:8080';
+
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './results/artifacts',
+  // Search results depend on shared, mutable site content, so specs must not race each other.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  // Generous: the first search in a page load waits on a real Elasticsearch round-trip.
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [['list'], ['junit', { outputFile: 'results/junit.xml' }], ['html', { open: 'never', outputFolder: 'results/report' }]]
+    : [['list'], ['html', { open: 'never', outputFolder: 'results/report' }]],
+  use: {
+    baseURL: jahiaUrl,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -56,11 +56,9 @@ grep -qiE '"?error|exception|failure' <<<"${response}" && die "provisioning repo
 # --- 3. The module under test ------------------------------------------------------------------
 # Prefer the jar CI just built (mounted at /artifacts); fall back to the released version so the
 # environment is usable standalone by anyone who just wants to see the module run.
-# /artifacts is the local Maven output (../target); /artifacts-ci is where the CI action drops the
-# jar it built in an earlier job. Whichever is present and newest wins.
+# /artifacts is ../target — the Maven output locally, and where CI puts the build job's jar.
 jar="${MODULE_JAR:-}"
-[[ -z "${jar}" ]] && jar=$(ls -t /artifacts/augmented-search-ui-*.jar /artifacts-ci/augmented-search-ui-*.jar \
-                              2>/dev/null | head -1 || true)
+[[ -z "${jar}" ]] && jar=$(ls -t /artifacts/augmented-search-ui-*.jar 2>/dev/null | head -1 || true)
 if [[ -n "${jar}" && -f "${jar}" ]]; then
     log "deploying $(basename "${jar}")…"
     deploy=$(curl -sS --max-time 600 "${AUTH[@]}" -X POST "${JAHIA_URL}/modules/api/provisioning" \

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Provision the environment, then hand over to the test runner.
+#
+# Runs INSIDE the tests container so that a provisioning failure shows up in the test job's own log
+# rather than buried in Jahia's startup output.
+#
+# Steps: wait for Jahia -> platform manifest -> deploy the module -> enable it on digitall ->
+# place + publish the component -> wait for Augmented Search indices.
+set -euo pipefail
+
+JAHIA_URL="${JAHIA_URL:-http://jahia:8080}"
+ELASTICSEARCH_URL="${ELASTICSEARCH_URL:-http://elasticsearch:9200}"
+SUPER_USER_PASSWORD="${SUPER_USER_PASSWORD:-root1234}"
+MANIFEST="${MANIFEST:-provisioning-manifest-stable.yml}"
+SITE_KEY="${SITE_KEY:-digitall}"
+COMPONENT_PATH="/sites/${SITE_KEY}/home/landing/augmented-search"
+
+# Every Jahia GraphQL call needs an Origin header matching the target. Without it the request is
+# treated as unauthenticated and any jcr query fails with "Permission denied" — an error that looks
+# like a permissions problem but is a missing header. Basic auth itself is fine.
+AUTH=(-u "root:${SUPER_USER_PASSWORD}" -H "Origin: ${JAHIA_URL}")
+
+log() { echo "$(date +'%H:%M:%S') [provision] $*"; }
+die() { echo "$(date +'%H:%M:%S') [provision] FATAL: $*" >&2; exit 1; }
+
+graphql() {
+    curl -sS --max-time 120 "${AUTH[@]}" -H 'Content-Type: application/json' \
+        -X POST "${JAHIA_URL}/modules/graphql" --data "$(jq -nc --arg q "$1" '{query: $q}')"
+}
+
+wait_for() { # wait_for <description> <seconds> <command...>
+    local what="$1" timeout="$2"; shift 2
+    local deadline=$(( SECONDS + timeout ))
+    log "waiting for ${what} (timeout ${timeout}s)…"
+    until "$@" >/dev/null 2>&1; do
+        (( SECONDS < deadline )) || die "timed out waiting for ${what}"
+        sleep 5
+    done
+    log "${what} ✓"
+}
+
+# --- 1. Jahia up ------------------------------------------------------------------------------
+wait_for "Jahia to serve /cms/login" 900 curl -sf "${JAHIA_URL}/cms/login"
+
+# --- 2. Platform (Digitall, Augmented Search, the JS-modules engine, ES configuration) --------
+# The manifest and the files it references travel in ONE multipart request; the manifest refers to
+# them by bare filename, which the provisioning API resolves against the uploaded parts.
+log "applying manifest ${MANIFEST}…"
+response=$(curl -sS --max-time 1800 "${AUTH[@]}" -X POST "${JAHIA_URL}/modules/api/provisioning" \
+    -F "script=@${MANIFEST};type=text/yaml" \
+    -F "file=@index-digitall.graphql")
+log "provisioning response: ${response}"
+# The API returns 200 with an error payload for some failures, so inspect the body.
+grep -qiE '"?error|exception|failure' <<<"${response}" && die "provisioning reported a problem"
+
+# --- 3. The module under test ------------------------------------------------------------------
+# Prefer the jar CI just built (mounted at /artifacts); fall back to the released version so the
+# environment is usable standalone by anyone who just wants to see the module run.
+# /artifacts is the local Maven output (../target); /artifacts-ci is where the CI action drops the
+# jar it built in an earlier job. Whichever is present and newest wins.
+jar="${MODULE_JAR:-}"
+[[ -z "${jar}" ]] && jar=$(ls -t /artifacts/augmented-search-ui-*.jar /artifacts-ci/augmented-search-ui-*.jar \
+                              2>/dev/null | head -1 || true)
+if [[ -n "${jar}" && -f "${jar}" ]]; then
+    log "deploying $(basename "${jar}")…"
+    deploy=$(curl -sS --max-time 600 "${AUTH[@]}" -X POST "${JAHIA_URL}/modules/api/provisioning" \
+        -F "script=[{\"installOrUpgradeBundle\": [\"$(basename "${jar}")\"], \"autoStart\": true}];type=application/json" \
+        -F "file=@${jar}")
+    log "deploy response: ${deploy}"
+    grep -qiE '"?error|exception|failure' <<<"${deploy}" && die "module deployment reported a problem"
+else
+    log "no local jar found — installing the released augmented-search-ui from the app store"
+    curl -sS --max-time 600 "${AUTH[@]}" -X POST "${JAHIA_URL}/modules/api/provisioning" \
+        -H 'Content-Type: application/json' \
+        --data '[{"installBundle":["mvn:org.jahia.modules/augmented-search-ui/4.0.0"],"autoStart":true,"uninstallPreviousVersion":true}]'
+fi
+
+# --- 4. Enable the module on the site ----------------------------------------------------------
+log "enabling augmented-search-ui on ${SITE_KEY}…"
+# Note: this operation returns an EMPTY body on success — silence is success, not failure.
+curl -sS --max-time 120 "${AUTH[@]}" -X POST "${JAHIA_URL}/modules/api/provisioning" \
+    -H 'Content-Type: application/json' \
+    --data "[{\"enable\":\"augmented-search-ui\",\"site\":\"${SITE_KEY}\"}]"
+
+# --- 5. Place and publish the search component -------------------------------------------------
+if graphql "query { jcr(workspace: EDIT) { nodeByPath(path: \"${COMPONENT_PATH}\") { uuid } } }" \
+        | grep -q '"uuid"'; then
+    log "component already present at ${COMPONENT_PATH}"
+else
+    log "adding sui:augmentedSearch at ${COMPONENT_PATH}…"
+    graphql "mutation { jcr { addNode(parentPathOrId: \"/sites/${SITE_KEY}/home/landing\", name: \"augmented-search\", primaryNodeType: \"sui:augmentedSearch\") { uuid } } }" \
+        | tee /dev/stderr | grep -q '"uuid"' || die "could not create the search component"
+fi
+log "publishing…"
+graphql "mutation { jcr(workspace: EDIT) { mutateNode(pathOrId: \"${COMPONENT_PATH}\") { publish(languages: [\"en\",\"fr\",\"de\"]) } } }" \
+    | tee /dev/stderr | grep -q '"publish":true' || die "could not publish the search component"
+
+# --- 6. Indexation actually finished -----------------------------------------------------------
+# Indexation is asynchronous and its mutation reports success even when the job later fails, so the
+# only trustworthy check is that non-empty indices exist.
+indexed() {
+    local docs
+    docs=$(curl -sf "${ELASTICSEARCH_URL}/_cat/indices/jahia_as*?h=docs.count" 2>/dev/null \
+           | tr -d ' ' | grep -vE '^0?$' | head -1)
+    [[ -n "${docs}" ]]
+}
+wait_for "Augmented Search indices to hold documents" 900 indexed
+curl -sf "${ELASTICSEARCH_URL}/_cat/indices/jahia_as*?v&h=index,docs.count" || true
+
+log "environment ready — handing over to the tests"
+exec "$@"

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -20,16 +20,27 @@ COMPONENT_PATH="/sites/${SITE_KEY}/home/landing/augmented-search"
 # like a permissions problem but is a missing header. Basic auth itself is fine.
 AUTH=(-u "root:${SUPER_USER_PASSWORD}" -H "Origin: ${JAHIA_URL}")
 
-log() { echo "$(date +'%H:%M:%S') [provision] $*"; }
-die() { echo "$(date +'%H:%M:%S') [provision] FATAL: $*" >&2; exit 1; }
+log() {
+    echo "$(date +'%H:%M:%S') [provision] $*"
+    return 0
+}
+
+die() {
+    echo "$(date +'%H:%M:%S') [provision] FATAL: $*" >&2
+    exit 1
+}
 
 graphql() {
+    local query="$1"
     curl -sS --max-time 120 "${AUTH[@]}" -H 'Content-Type: application/json' \
-        -X POST "${JAHIA_URL}/modules/graphql" --data "$(jq -nc --arg q "$1" '{query: $q}')"
+        -X POST "${JAHIA_URL}/modules/graphql" --data "$(jq -nc --arg q "${query}" '{query: $q}')"
+    return $?
 }
 
 wait_for() { # wait_for <description> <seconds> <command...>
-    local what="$1" timeout="$2"; shift 2
+    local what="$1"
+    local timeout="$2"
+    shift 2
     local deadline=$(( SECONDS + timeout ))
     log "waiting for ${what} (timeout ${timeout}s)…"
     until "$@" >/dev/null 2>&1; do
@@ -37,6 +48,7 @@ wait_for() { # wait_for <description> <seconds> <command...>
         sleep 5
     done
     log "${what} ✓"
+    return 0
 }
 
 # --- 1. Jahia up ------------------------------------------------------------------------------
@@ -57,8 +69,16 @@ grep -qiE '"?error|exception|failure' <<<"${response}" && die "provisioning repo
 # Prefer the jar CI just built (mounted at /artifacts); fall back to the released version so the
 # environment is usable standalone by anyone who just wants to see the module run.
 # /artifacts is ../target — the Maven output locally, and where CI puts the build job's jar.
+#
+# Excluding -sources/-javadoc matters: the Maven build (and so the CI artifact) contains
+# augmented-search-ui-<version>-sources.jar alongside the module jar, and picking the newest match
+# blindly can deploy the sources jar.
 jar="${MODULE_JAR:-}"
-[[ -z "${jar}" ]] && jar=$(ls -t /artifacts/augmented-search-ui-*.jar 2>/dev/null | head -1 || true)
+if [[ -z "${jar}" ]]; then
+    jar=$(find /artifacts -maxdepth 1 -name 'augmented-search-ui-*.jar' \
+            ! -name '*-sources.jar' ! -name '*-javadoc.jar' -printf '%T@ %p\n' 2>/dev/null \
+          | sort -rn | head -1 | cut -d' ' -f2-)
+fi
 if [[ -n "${jar}" && -f "${jar}" ]]; then
     log "deploying $(basename "${jar}")…"
     deploy=$(curl -sS --max-time 600 "${AUTH[@]}" -X POST "${JAHIA_URL}/modules/api/provisioning" \
@@ -100,7 +120,8 @@ indexed() {
     local docs
     docs=$(curl -sf "${ELASTICSEARCH_URL}/_cat/indices/jahia_as*?h=docs.count" 2>/dev/null \
            | tr -d ' ' | grep -vE '^0?$' | head -1)
-    [[ -n "${docs}" ]]
+    [[ -n "${docs}" ]] && return 0
+    return 1
 }
 wait_for "Augmented Search indices to hold documents" 900 indexed
 curl -sf "${ELASTICSEARCH_URL}/_cat/indices/jahia_as*?v&h=index,docs.count" || true

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -117,7 +117,7 @@ graphql "mutation { jcr(workspace: EDIT) { mutateNode(pathOrId: \"${COMPONENT_PA
 
 # --- 6. Indexation actually finished -----------------------------------------------------------
 # Indexation is asynchronous and its mutation reports success even when the job later fails, so the
-# only trustworthy check is that non-empty indices exist.
+# only trustworthy check is the end state.
 indexed() {
     local docs
     docs=$(curl -sf "${ELASTICSEARCH_URL}/_cat/indices/jahia_as*?h=docs.count" 2>/dev/null \
@@ -126,6 +126,30 @@ indexed() {
     return 1
 }
 wait_for "Augmented Search indices to hold documents" 900 indexed
+
+# Non-empty is not the same as finished. The tests assert exact result totals, so wait until the
+# count STOPS CHANGING - otherwise the suite races a still-running indexation and the totals differ
+# between runs. Two consecutive identical readings is enough in practice.
+total_hits() {
+    graphql 'query { search(q: "", workspace: LIVE) { results(size: 1) { totalHits } } }' 2>/dev/null \
+        | jq -r '.data.search.results.totalHits // empty'
+}
+log "waiting for indexation to settle…"
+settle_deadline=$(( SECONDS + 900 ))
+previous=""
+stable=0
+while (( stable < 2 )); do
+    current=$(total_hits)
+    if [[ -n "${current}" && "${current}" != "0" && "${current}" == "${previous}" ]]; then
+        stable=$(( stable + 1 ))
+    else
+        stable=0
+    fi
+    previous="${current}"
+    (( SECONDS < settle_deadline )) || die "indexation did not settle (last count: ${current:-none})"
+    sleep 10
+done
+log "indexation settled at ${previous} documents (LIVE, default language) ✓"
 curl -sf "${ELASTICSEARCH_URL}/_cat/indices/jahia_as*?v&h=index,docs.count" || true
 
 log "environment ready — handing over to the tests"

--- a/tests/provision.sh
+++ b/tests/provision.sh
@@ -27,6 +27,8 @@ log() {
 
 die() {
     echo "$(date +'%H:%M:%S') [provision] FATAL: $*" >&2
+    # NOSONAR (S7682: no explicit return) - this function deliberately terminates the script, so a
+    # trailing `return` would be unreachable dead code.
     exit 1
 }
 

--- a/tests/provisioning-manifest-stable.yml
+++ b/tests/provisioning-manifest-stable.yml
@@ -1,0 +1,74 @@
+# Platform provisioning for the augmented-search-ui test / demo environment.
+#
+# STABLE VERSIONS ONLY — this manifest is also what a customer runs to try the module, so every
+# coordinate is a released version. Never introduce a -SNAPSHOT here.
+#
+# Scope: everything EXCEPT augmented-search-ui itself. The module under test is deployed separately
+# (from the jar CI just built), so this manifest describes only the platform it needs.
+#
+# Provisioning API reference:
+# https://github.com/Jahia/jahia-private/blob/master/bundles/provisioning/README.md
+
+# --- Digitall demo site: the content to search -------------------------------------------------
+- installBundle:
+    - 'mvn:org.jahia.modules/bookmarks/3.1.0'
+    - 'mvn:org.jahia.modules/bootstrap3-core/4.3.0'
+    - 'mvn:org.jahia.modules/bootstrap3-components/4.3.0'
+    - 'mvn:org.jahia.modules/calendar/3.2.0'
+    - 'mvn:org.jahia.modules/digitall/3.0.0'
+    - 'mvn:org.jahia.modules/dx-base-demo-components/3.0.0'
+    - 'mvn:org.jahia.modules/dx-base-demo-core/2.6.0'
+    - 'mvn:org.jahia.modules/dx-base-demo-templates/4.0.0'
+    - 'mvn:org.jahia.modules/event/4.0.1'
+    - 'mvn:org.jahia.modules/font-awesome/6.1.5'
+    - 'mvn:org.jahia.modules/location/3.2.0'
+    - 'mvn:org.jahia.modules/news/3.4.0'
+    - 'mvn:org.jahia.modules/person/3.2.0'
+    - 'mvn:org.jahia.modules/press/3.1.0'
+    - 'mvn:org.jahia.modules/rating/3.3.0'
+    - 'mvn:org.jahia.modules/topstories/3.0.0'
+    - 'mvn:org.jahia.modules/legacy-detault-components/1.0.0'
+    - 'mvn:org.jahia.modules/skins/8.2.0'
+    - 'mvn:org.jahia.modules/default-skins/8.2.0'
+    - 'mvn:org.jahia.modules/grid/8.1.0'
+    - 'mvn:org.jahia.modules/tabularList/8.2.0'
+  autoStart: true
+  uninstallPreviousVersion: true
+
+- import: "jar:mvn:org.jahia.modules/digitall/3.0.0/zip/import!/users.zip"
+- importSite: "jar:mvn:org.jahia.modules/digitall/3.0.0/zip/import!/Digitall.zip"
+
+# --- Augmented Search ships from the PUBLIC Jahia app-store repo (no credentials needed) -------
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/repositories/jahia-public-app-store@id=JahiaStore'
+
+# --- Point the Elasticsearch connector at the `elasticsearch` service -------------------------
+# Configuration BEFORE the bundle: Config Admin stores configuration independently of the bundle,
+# so the connector activates already-configured instead of starting wrong and needing a restart.
+#
+# Augmented Search 4.x is configured this way. Older tutorials create a JCR
+# `ec:elasticsearchConnection` node with a Groovy script and call `setDbConnection` — that node type
+# no longer exists in 4.x, and `database-connector` is no longer a dependency.
+- editConfiguration: "org.jahia.modules.elasticsearchConnector"
+  properties:
+    elasticsearchConnector.host: "elasticsearch"
+    elasticsearchConnector.port: "9200"
+    elasticsearchConnector.useXPackSecurity: "false"
+    elasticsearchConnector.useEncryption: "false"
+
+# --- Augmented Search + the JavaScript-modules engine -----------------------------------------
+# The engine is needed by the JavaScript-module flavour of augmented-search-ui (5.x). Keep the
+# engine version in step with @jahia/javascript-modules-library in package.json.
+- installBundle:
+    - 'mvn:org.jahia.modules/elasticsearch-connector/4.1.0'
+    - 'mvn:org.jahia.modules/augmented-search/4.1.0'
+    - 'mvn:org.jahia.modules/javascript-modules-engine/1.2.0'
+  autoStart: true
+  uninstallPreviousVersion: true
+
+# --- Register Digitall with Augmented Search and index it -------------------------------------
+# Let the connector reach Elasticsearch and the modules settle before indexing.
+- sleep: 15000
+# Bare filename, no URL scheme: the provisioning API resolves it against the files uploaded
+# alongside this manifest in the same multipart request (see provision.sh). A path such as
+# `file:/tmp/...` would have to exist inside the JAHIA container, which it does not.
+- executeScript: "index-digitall.graphql"

--- a/tests/support/expected.ts
+++ b/tests/support/expected.ts
@@ -1,0 +1,127 @@
+/**
+ * What the Digitall demo site is expected to contain.
+ *
+ * These are CHARACTERISATION values, captured from the module as it behaves today. They are exact on
+ * purpose: this suite exists to detect behaviour changes during the migration to a Jahia JavaScript
+ * module, and a fuzzy assertion detects nothing.
+ *
+ * They are stable because the environment pins everything: Digitall 3.0.0, augmented-search 4.1.0,
+ * and `provision.sh` waits for indexation to *settle* before the suite starts.
+ *
+ * If one of these fails after a content or version bump, the value is what needs updating — but
+ * check first that the behaviour genuinely changed rather than reflexively editing the number.
+ */
+
+/** Live pages, one per site language. Digitall's default language is `en`. */
+export const PAGES = {
+  en: '/sites/digitall/home.html',
+  fr: '/fr/sites/digitall/home.html',
+  de: '/de/sites/digitall/home.html',
+} as const;
+
+export type Language = keyof typeof PAGES;
+
+/** Total LIVE documents for an empty query — identical across the three languages. */
+export const TOTAL_RESULTS = 61;
+
+/** Search UI's default page size, and the options offered by the ResultsPerPage override. */
+export const DEFAULT_PAGE_SIZE = 20;
+export const PAGE_SIZE_OPTIONS = ['20', '40', '60'] as const;
+
+/** Sort options, in the order SearchView declares them. */
+export const SORT_OPTIONS = {
+  created: { label: 'Creation date', field: 'jcr:created', direction: 'desc' },
+  modified: { label: 'Updated date', field: 'jcr:lastModified', direction: 'desc' },
+  relevance: { label: 'Relevance', field: '', direction: '' },
+  title: { label: 'Title', field: 'jcr:title.keyword', direction: 'asc' },
+} as const;
+
+/** Facet values Digitall actually produces. */
+export const FACETS = {
+  /** The `jgql:categories_path` tree facet. "Annual Filings" is a leaf here — no children to expand. */
+  categories: [{ value: 'Annual Filings', count: 8 }],
+  /** `jcr:tags`, ordered by descending count as returned. */
+  tags: [
+    { value: 'health', count: 3 },
+    { value: 'food', count: 2 },
+    { value: 'movies', count: 2 },
+  ],
+  /**
+   * The `jcr:lastModified` date_range facet. Every count is 0: Digitall's content was last modified
+   * in 2016 and the ranges are relative to *now*, so nothing falls inside them. The options still
+   * render and remain clickable, which is what makes them testable.
+   */
+  lastModifiedRanges: [
+    'Last 5 years',
+    'Last year',
+    'Last 6 months',
+    'Last month',
+    'Last Week',
+  ],
+} as const;
+
+/**
+ * Facets that are configured but never rendered on Digitall, for opposite reasons:
+ *  - `jcr:lastModifiedBy` ("Author") is a **conditionalFacet**: SearchView only requests it while a
+ *    `jcr:lastModified` filter is active. Digitall content *is* authored (by `root`), so its absence
+ *    proves the condition, not a lack of data.
+ *  - `jcr:keywords` ("Keywords") simply has no values in Digitall, and Search UI renders nothing for
+ *    a facet with no options.
+ */
+export const ABSENT_FACET_TITLES = ['AUTHOR', 'KEYWORDS'] as const;
+
+/** A term with a known, stable number of hits. */
+export const KNOWN_QUERY = { term: 'movies', hits: 20 } as const;
+
+/** A term that matches nothing, for the empty-state path. */
+export const NO_MATCH_QUERY = 'zzzzqqqqnothingmatchesthis';
+
+/**
+ * UI strings per language.
+ *
+ * ⚠ `de` deliberately holds the ENGLISH strings. `i18n/resources.js` registers only `en` and `fr`,
+ * so although `i18n/de.json` exists it is never loaded and i18next falls back to `en`
+ * (`fallbackLng: 'en'`). That is a bug in the module; this suite records the behaviour as it is so
+ * the migration cannot change it unnoticed. See the note in i18n.spec.ts.
+ */
+export const LABELS = {
+  en: {
+    placeholder: 'Search',
+    submit: 'Search',
+    sortBy: 'Sort by',
+    show: 'Show',
+    facetTitles: ['Categories', 'Tags', 'Last modified'],
+    pagingInfoAll: `Showing 1 - ${DEFAULT_PAGE_SIZE} out of ${TOTAL_RESULTS}`,
+    createdAt: 'created at',
+  },
+  fr: {
+    placeholder: 'Rechercher',
+    submit: 'Rechercher',
+    sortBy: 'Ordonner par',
+    show: 'Afficher',
+    facetTitles: ['Catégories', 'Tags', 'Dernière modification'],
+    pagingInfoAll: `Affiche 1 - ${DEFAULT_PAGE_SIZE} sur ${TOTAL_RESULTS}`,
+    createdAt: 'créé le',
+  },
+  de: {
+    // English on purpose — see the warning above.
+    placeholder: 'Search',
+    submit: 'Search',
+    sortBy: 'Sort by',
+    show: 'Show',
+    facetTitles: ['Categories', 'Tags', 'Last modified'],
+    pagingInfoAll: `Showing 1 - ${DEFAULT_PAGE_SIZE} out of ${TOTAL_RESULTS}`,
+    createdAt: 'created at',
+  },
+} as const;
+
+/**
+ * The empty-results message. Hardcoded in SearchView as `fallbackView="Nothing was found"` rather
+ * than read from the `search.fallbackMsg` i18n key, so it is English in every language even though
+ * translations exist. Another behaviour recorded as-is.
+ */
+export const NO_RESULTS_MESSAGE = 'Nothing was found';
+
+/** A title that is first when sorting ascending by title, and one that is first by creation date. */
+export const FIRST_BY_TITLE = 'Hegebottom';
+export const FIRST_BY_CREATED = 'Search Results';

--- a/tests/support/search-page.ts
+++ b/tests/support/search-page.ts
@@ -1,0 +1,158 @@
+import { type Page, type Locator, expect } from '@playwright/test';
+import { PAGES, type Language } from './expected.js';
+
+/**
+ * Page object for the augmented-search-ui component.
+ *
+ * All knowledge of the rendered DOM lives here, deliberately: the suite may be ported to Cypress
+ * later, and the specs should then need no changes beyond the driver calls.
+ *
+ * Selector rules learned the hard way — keep them:
+ *  - **Never select on `input[type="text"]`.** Elastic's SearchBox renders its field with no `type`
+ *    attribute at all, so an attribute selector cannot match it. Use the textbox role.
+ *  - **Never select on the tree facet's classes.** They are styled-components hashes
+ *    (`sc-beySPh gNyMxS`) that change on every build. Use roles and text.
+ *  - **Avoid `react-select-N-*` ids** (sort / results-per-page). They are ordinal and shift when the
+ *    number of selects on the page changes. `classNamePrefix="sui-select"` gives stable class names.
+ *  - **Avoid comma-separated CSS inside a chained locator.** Playwright splits it at the top level,
+ *    so the second alternative escapes the container scope.
+ */
+export class SearchPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  /** The container the module mounts into; its id carries the content node's uuid. */
+  get app(): Locator {
+    return this.page.locator('[id^="augmentedSearchUIApp_"]');
+  }
+
+  get input(): Locator {
+    return this.app.getByRole('textbox').first();
+  }
+
+  get submitButton(): Locator {
+    return this.app.locator('input[type="submit"]');
+  }
+
+  get pagingInfo(): Locator {
+    return this.app.locator('.sui-paging-info');
+  }
+
+  get results(): Locator {
+    return this.app.locator('.result');
+  }
+
+  get resultTitles(): Locator {
+    return this.app.locator('.result .title');
+  }
+
+  get sortLabel(): Locator {
+    return this.app.locator('.sui-sorting__label');
+  }
+
+  get pageSizeLabel(): Locator {
+    return this.app.locator('.sui-results-per-page__label');
+  }
+
+  get facetTitles(): Locator {
+    return this.app.locator('.sui-facet__title');
+  }
+
+  get pagination(): Locator {
+    return this.app.locator('.sui-paging');
+  }
+
+  /** Open a language's home page and wait until the React app has actually mounted. */
+  async goto(language: Language = 'en', query?: string): Promise<void> {
+    const url = query ? `${PAGES[language]}?${query}` : PAGES[language];
+    await this.page.goto(url);
+    await this.waitUntilMounted();
+  }
+
+  /**
+   * The JSP renders `<div id=…>Loading...</div>` and the bundle replaces it, so the container exists
+   * long before the app does. The search field is the first thing that proves React has mounted.
+   */
+  async waitUntilMounted(): Promise<void> {
+    await expect(this.app).toBeAttached();
+    await this.input.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Type a query. The SearchBox uses `searchAsYouType` with `debounceLength={0}`, so filling the
+   * field is enough — there is no need to submit.
+   */
+  async search(term: string): Promise<void> {
+    await this.input.fill(term);
+  }
+
+  /** A facet block, located by its visible legend. Case-insensitive: CSS uppercases the legend. */
+  facet(title: string | RegExp): Locator {
+    return this.app
+      .locator('fieldset.sui-facet')
+      .filter({ has: this.page.locator('legend', { hasText: title }) });
+  }
+
+  /** A checkbox option inside a standard (non-tree) facet. */
+  facetOption(facetTitle: string | RegExp, value: string): Locator {
+    return this.facet(facetTitle)
+      .locator('label.sui-multi-checkbox-facet__option-label')
+      .filter({ has: this.page.getByText(value, { exact: true }) });
+  }
+
+  /** The count badge next to a checkbox facet option. */
+  facetOptionCount(facetTitle: string | RegExp, value: string): Locator {
+    return this.facetOption(facetTitle, value).locator('.sui-multi-checkbox-facet__option-count');
+  }
+
+  async toggleFacetOption(facetTitle: string | RegExp, value: string): Promise<void> {
+    await this.facetOption(facetTitle, value).click();
+  }
+
+  /**
+   * A node in the Categories tree facet. TreeNode renders the value in a `span[role="button"]`, with
+   * the count in a sibling span — no classes worth relying on.
+   */
+  treeNode(value: string): Locator {
+    return this.facet(/categories|catégories|kategorien/i)
+      .getByRole('button')
+      .filter({ hasText: value });
+  }
+
+  /** Choose an option in one of the react-select dropdowns (sort, results-per-page). */
+  private async chooseInSelect(container: Locator, optionText: string): Promise<void> {
+    await container.locator('.sui-select__control').click();
+    // The menu portals to the page root, so it is NOT inside `container`.
+    await this.page.locator('.sui-select__option').filter({ hasText: optionText }).first().click();
+  }
+
+  async sortBy(optionLabel: string): Promise<void> {
+    await this.chooseInSelect(this.app.locator('.sui-sorting'), optionLabel);
+  }
+
+  async setPageSize(size: string): Promise<void> {
+    await this.chooseInSelect(this.app.locator('.sui-results-per-page'), size);
+  }
+
+  /** The value currently shown by a react-select. */
+  selectedValueOf(which: 'sorting' | 'results-per-page'): Locator {
+    const root = which === 'sorting' ? '.sui-sorting' : '.sui-results-per-page';
+    return this.app.locator(`${root} .sui-select__single-value`);
+  }
+
+  async gotoPage(n: number): Promise<void> {
+    await this.app.locator(`li.rc-pagination-item-${n} a`).click();
+  }
+
+  get activePage(): Locator {
+    return this.app.locator('li.rc-pagination-item-active');
+  }
+
+  /** Query-state parameters Search UI keeps in the URL. */
+  urlParams(): URLSearchParams {
+    return new URL(this.page.url()).searchParams;
+  }
+}


### PR DESCRIPTION
This module had **no automated tests at all**, and standing up a Jahia with Augmented Search was undocumented and fiddly. Adds a complete environment under `tests/`, plus an integration-tests CI job.

Two audiences, one environment: CI, and anyone — us or a customer — who wants to see the module running before forking it. So everything is pinned to **stable released versions**: Jahia 8.2, `augmented-search` 4.1.0, `elasticsearch-connector` 4.1.0, `javascript-modules-engine` 1.2.0, digitall 3.0.0. No licence is shipped; the caller supplies `JAHIA_LICENSE`.

```bash
cd tests
export JAHIA_LICENSE=$(base64 -i /path/to/license.xml)
docker compose up -d elasticsearch jahia
docker compose up --build --abort-on-container-exit playwright
```

## The non-obvious bits

**Elasticsearch is built, not pulled.** `augmented-search` creates its indices with analyzers that live in ES plugins — `analysis-icu` always, plus `stempel`/`kuromoji` for pl/ja, as declared in the module's own `settings*.json`. Against stock Elasticsearch, index creation fails and the reindex job dies with `failed to find tokenizer under name [icu_tokenizer]`, which reads like a Jahia bug and isn't.

**`provision.sh` verifies end state, not return values.** Indexation is asynchronous and `startIndex` reports success even when the job fails a minute later, leaving an environment that looks provisioned and answers every search with `index_not_found_exception`. So it waits for indices to actually hold documents. It also runs *inside* the tests container, so provisioning failures land in the test job's log instead of Jahia's startup output.

**The manifest references its GraphQL file by bare filename.** The provisioning API resolves those against files uploaded in the same multipart request. A `file:/...` path would have to exist inside the *Jahia* container.

## Scope

The Playwright suite is deliberately a smoke test: it proves Jahia, Augmented Search, Elasticsearch and the module are talking to each other (3 tests — component renders, a search returns rendered results, and a direct GraphQL check so a UI regression and a broken index fail differently). The behavioural suite covering search, facets, the custom `TreeFacet`, paging, sorting and i18n comes next — it's the safety net for the JavaScript-module migration.

## Draft, because of the CI job

The `integration-tests` job is my best reading of `jahia-modules-action/integration-tests` conventions and **has never been exercised**. `provision.sh` looks for the jar in both `/artifacts` and `/artifacts-ci` and falls back to the released module, so it should degrade gracefully rather than hard-fail — but expect a round of fixing.

Worth knowing: the environment itself is **not coupled to that action**. `docker-compose.yml` + `provision.sh` work under plain `docker compose`, which is exactly how I ran them locally. If the shared action fights back, replacing it with a local pipeline is a small step, not a rewrite.